### PR TITLE
Add source and author metadata to SKILL.md for improved documentation

### DIFF
--- a/skills/code-connect-components/SKILL.md
+++ b/skills/code-connect-components/SKILL.md
@@ -3,6 +3,8 @@ name: code-connect-components
 description: Connects Figma design components to code components using Code Connect. Use when user says "code connect", "connect this component to code", "connect Figma to code", "map this component", "link component to code", "create code connect mapping", "add code connect", "connect design to code", or wants to establish mappings between Figma designs and code implementations. Requires Figma MCP server connection.
 metadata:
   mcp-server: figma
+  source: https://github.com/figma/mcp-server-guide
+  author: Figma
 ---
 
 # Code Connect Components

--- a/skills/create-design-system-rules/SKILL.md
+++ b/skills/create-design-system-rules/SKILL.md
@@ -3,6 +3,8 @@ name: create-design-system-rules
 description: Generates custom design system rules for the user's codebase. Use when user says "create design system rules", "generate rules for my project", "set up design rules", "customize design system guidelines", or wants to establish project-specific conventions for Figma-to-code workflows. Requires Figma MCP server connection.
 metadata:
   mcp-server: figma
+  source: https://github.com/figma/mcp-server-guide
+  author: Figma
 ---
 
 # Create Design System Rules

--- a/skills/implement-design/SKILL.md
+++ b/skills/implement-design/SKILL.md
@@ -3,6 +3,8 @@ name: implement-design
 description: Translates Figma designs into production-ready code with 1:1 visual fidelity. Use when implementing UI from Figma files, when user mentions "implement design", "generate code", "implement component", "build Figma design", provides Figma URLs, or asks to build components matching Figma specs. Requires Figma MCP server connection.
 metadata:
   mcp-server: figma
+  source: https://github.com/figma/mcp-server-guide
+  author: Figma
 ---
 
 # Implement Design


### PR DESCRIPTION
You do not have issues active for the repo therefore I just created a PR without an issue. My assumption is that people will start to copy skills (SKILL.md) and there I believe it makes sense to have the origin part of the skin.

Next to that the repo is missing a license. I'´m happy to create a second PR and add a license (in SKILL.md head, too) if you tell me what license should be added.