### PR TITLE
Add marketplace.json for Claude Code marketplace installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "figma",
+  "owner": {
+    "name": "Figma"
+  },
+  "metadata": {
+    "description": "Figma MCP server and Skills for common workflows",
+    "version": "1.2.0"
+  },
+  "plugins": [
+    {
+      "name": "figma",
+      "source": "./",
+      "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
+      "version": "1.2.0",
+      "author": {
+        "name": "Figma"
+      },
+      "category": "design",
+      "keywords": [
+        "figma",
+        "mcp",
+        "design",
+        "code-connect",
+        "design-system"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` so the repo can be installed via Claude Code's `/plugin → Add Marketplace → figma/mcp-server-guide`

Currently, attempting this fails with:
```
Marketplace file not found at .../.claude/plugins/marketplaces/figma-mcp-server-guide/.claude-plugin/marketplace.json
```

The repo already has `.claude-plugin/plugin.json`, but Claude Code's "Add Marketplace" flow specifically looks for `marketplace.json`. This PR adds it following the same schema used by other working marketplace plugins.

## Test plan

- [x] Run `/plugin → Add Marketplace → figma/mcp-server-guide` in Claude Code and verify it installs successfully