### PR TITLE
Some Code Connect Skill updates to bring inline with recommended templates usage

### DIFF
--- a/skills/figma-code-connect/SKILL.md
+++ b/skills/figma-code-connect/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: false
 
 Create parserless Code Connect template files (`.figma.ts`) that map Figma components to code snippets. Given a Figma URL, follow the steps below to create a template.
 
-> **Note:** This project may also contain parser-based `.figma.tsx` files (using `figma.connect()`, published via CLI). This skill covers **parserless templates only** — `.figma.ts` files that use the MCP tools to fetch component context from Figma.
+> **Note:** This project may also contain parser-based `.figma.tsx` files (using `figma.connect()`, published via CLI). This skill covers **templates files only** — `.figma.ts` files that use the MCP tools to fetch component context from Figma.
 
 ## Prerequisites
 
@@ -96,7 +96,7 @@ Read the code component's source to understand its props interface — this info
 
 ### File location
 
-Place the file alongside existing Code Connect templates (`.figma.tsx` or `.figma.ts` files). Check `figma.config.json` `include` patterns for the correct directory. Name it `ComponentName.figma.ts`.
+Place the file alongside existing Code Connect templates (`.figma.code` or `.figma.ts` files). Check `figma.config.json` `include` patterns for the correct directory. Name it `ComponentName.figma.ts`.
 
 ### Template structure
 
@@ -113,7 +113,7 @@ const instance = figma.selectedInstance
 // ...
 
 export default {
-  example: figma.tsx`<Component ... />`,       // Required: code snippet
+  example: figma.code`<Component ... />`,       // Required: code snippet
   imports: ['import { Component } from "..."'], // Optional: import statements
   id: 'component-name',                         // Required: unique identifier
   metadata: {                                    // Optional
@@ -162,7 +162,7 @@ const disabled = instance.getBoolean('Disabled')
 
 // Mapped to code values
 const hasIcon = instance.getBoolean('Has Icon', {
-  true: figma.tsx`<Icon />`,
+  true: figma.code`<Icon />`,
   false: undefined,
 })
 ```
@@ -208,7 +208,7 @@ if (icon && icon.hasCodeConnect()) {
 }
 
 export default {
-  example: figma.tsx`<Button ${iconSnippet ? figma.tsx`icon={${iconSnippet}}` : ''}>${label}</Button>`,
+  example: figma.code`<Button ${iconSnippet ? figma.code`icon={${iconSnippet}}` : ''}>${label}</Button>`,
   // ...
 }
 ```
@@ -220,7 +220,7 @@ const variant = instance.getEnum('Variant', { 'Primary': 'primary', 'Secondary':
 const disabled = instance.getBoolean('Disabled')
 
 export default {
-  example: figma.tsx`
+  example: figma.code`
     <Button
       variant="${variant}"
       ${disabled ? 'disabled' : ''}
@@ -232,18 +232,6 @@ export default {
 }
 ```
 
-### Tagged template literals
-
-Use the tagged template matching your target language:
-
-| Template | Language |
-|---|---|
-| `figma.tsx` | React / JSX / TypeScript |
-| `figma.html` | HTML / Web Components |
-| `figma.swift` | Swift |
-| `figma.kotlin` | Kotlin |
-| `figma.code` | Generic / fallback |
-
 ## Step 6: Validate
 
 Read back the `.figma.ts` file and review it against the following:
@@ -251,7 +239,6 @@ Read back the `.figma.ts` file and review it against the following:
 - **Property coverage** — every Figma property from Step 3 should be accounted for in the template. Flag any that are missing and ask the user if they were intentionally omitted.
 - **Rules and Pitfalls** — check for the common mistakes listed below (string concatenation of template results, missing `hasCodeConnect()` guards, missing `type === 'INSTANCE'` checks, etc.)
 - **Interpolation wrapping** — strings (`getString`, `getEnum`, `textContent`) wrapped in quotes, instance/section values (`executeTemplate().example`) wrapped in braces, booleans using conditionals
-- **Tagged template** — confirm it matches the project's framework (e.g. `figma.tsx` for React, not `figma.code`)
 
 If anything looks uncertain, consult [api.md](references/api.md) for API details and [advanced-patterns.md](references/advanced-patterns.md) for complex nesting.
 
@@ -297,27 +284,16 @@ If anything looks uncertain, consult [api.md](references/api.md) for API details
 
 ```ts
 export default {
-  example: figma.tsx`...`,                      // Required: ResultSection[]
+  example: figma.code`...`,                      // Required: ResultSection[]
   id: 'component-name',                         // Required: string
   imports: ['import { X } from "..."'],          // Optional: string[]
   metadata: { nestable: true, props: {} }        // Optional
 }
 ```
 
-### Tagged Template Types
-
-| Tag | Language |
-|---|---|
-| `figma.tsx` | React / JSX / TypeScript |
-| `figma.jsx` | React JavaScript |
-| `figma.html` | HTML / Web Components |
-| `figma.swift` | Swift |
-| `figma.kotlin` | Kotlin |
-| `figma.code` | Generic / fallback |
-
 ## Rules and Pitfalls
 
-1. **Never string-concatenate template results.** `executeTemplate().example` is a `ResultSection[]` object, not a string. Using `+` or `.join()` produces `[object Object]`. Always interpolate inside tagged templates: `` figma.tsx`${snippet1}${snippet2}` ``
+1. **Never string-concatenate template results.** `executeTemplate().example` is a `ResultSection[]` object, not a string. Using `+` or `.join()` produces `[object Object]`. Always interpolate inside tagged templates: `` figma.code`${snippet1}${snippet2}` ``
 
 2. **Always check `hasCodeConnect()` before `executeTemplate()`.** Calling `executeTemplate()` on an instance without Code Connect returns an error section.
 
@@ -327,9 +303,7 @@ export default {
 
 5. **Property names are case-sensitive** and must exactly match what `get_context_for_code_connect` returns.
 
-6. **Use the correct tagged template** for the target language (`figma.tsx` for React, `figma.html` for HTML, etc.). Avoid `figma.code` when a specific one is available.
-
-7. **Handle multiple template arrays correctly.** When iterating over children, set each result in a separate variable and interpolate them individually — do not use `.map().join()`:
+6. **Handle multiple template arrays correctly.** When iterating over children, set each result in a separate variable and interpolate them individually — do not use `.map().join()`:
    ```ts
    // Wrong:
    items.map(n => n.executeTemplate().example).join('\n')
@@ -337,7 +311,7 @@ export default {
    // Correct — use separate variables:
    const child1 = items[0]?.executeTemplate().example
    const child2 = items[1]?.executeTemplate().example
-   export default { example: figma.tsx`${child1}${child2}` }
+   export default { example: figma.code`${child1}${child2}` }
    ```
 
 ## Complete Worked Example
@@ -391,12 +365,12 @@ if (icon && icon.hasCodeConnect()) {
 }
 
 export default {
-  example: figma.tsx`
+  example: figma.code`
     <Button
       variant="${variant}"
       size="${size}"
       ${disabled ? 'disabled' : ''}
-      ${iconCode ? figma.tsx`icon={${iconCode}}` : ''}
+      ${iconCode ? figma.code`icon={${iconCode}}` : ''}
     >
       ${label}
     </Button>

--- a/skills/figma-code-connect/SKILL.md
+++ b/skills/figma-code-connect/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: figma-code-connect
-description: Creates and maintains Figma Code Connect template files that map Figma components to code snippets. Use when the user mentions Code Connect, Figma component mapping, design-to-code translation, or asks to create/update .figma.js files.
+description: Creates and maintains Figma Code Connect template files that map Figma components to code snippets. Use when the user mentions Code Connect, Figma component mapping, design-to-code translation, or asks to create/update .figma.ts or .figma.js files.
 disable-model-invocation: false
 ---
 
 ## Overview
 
-Create parserless Code Connect template files (`.figma.js`) that map Figma components to code snippets. Given a Figma URL, follow the steps below to create a template.
+Create parserless Code Connect template files (`.figma.ts`) that map Figma components to code snippets. Given a Figma URL, follow the steps below to create a template.
 
-> **Note:** This project may also contain parser-based `.figma.tsx` files (using `figma.connect()`, published via CLI). This skill covers **parserless templates only** — `.figma.js` files that use the MCP tools to fetch component context from Figma.
+> **Note:** This project may also contain parser-based `.figma.tsx` files (using `figma.connect()`, published via CLI). This skill covers **parserless templates only** — `.figma.ts` files that use the MCP tools to fetch component context from Figma.
 
 ## Prerequisites
 
@@ -16,6 +16,14 @@ Create parserless Code Connect template files (`.figma.js`) that map Figma compo
 - **Components must be published** — Code Connect only works with components published to a Figma team library. If a component is not published, inform the user and stop.
 - **Organization or Enterprise plan required** — Code Connect is not available on Free or Professional plans.
 - **URL must include `node-id`** — the Figma URL must contain the `node-id` query parameter.
+- **TypeScript types** — for editor autocomplete and type checking in `.figma.ts` files `@figma/code-connect/figma-types` must be added to `types` in `tsconfig.json`:
+  ```json
+  {
+    "compilerOptions": {
+      "types": ["@figma/code-connect/figma-types"]
+    }
+  }
+  ```
 
 ## Step 1: Parse the Figma URL
 
@@ -88,17 +96,17 @@ Read the code component's source to understand its props interface — this info
 
 ### File location
 
-Place the file alongside existing Code Connect templates (`.figma.tsx` or `.figma.js` files). Check `figma.config.json` `include` patterns for the correct directory. Name it `ComponentName.figma.js`.
+Place the file alongside existing Code Connect templates (`.figma.tsx` or `.figma.ts` files). Check `figma.config.json` `include` patterns for the correct directory. Name it `ComponentName.figma.ts`.
 
 ### Template structure
 
 Every parserless template follows this structure:
 
-```js
+```ts
 // url=https://www.figma.com/file/{fileKey}/{fileName}?node-id={nodeId}
 // source={path to code component from Step 4}
 // component={code component name from Step 4}
-const figma = require('figma')
+import figma from 'figma'
 const instance = figma.selectedInstance
 
 // Extract properties from the Figma component (see property mapping below)
@@ -129,12 +137,12 @@ Use the property list from Step 3 to extract values. For each Figma property typ
 | (text layer) | `instance.findText('LayerName')` → `.textContent` | Text content from named layers |
 
 **TEXT** — get the string value directly:
-```js
+```ts
 const label = instance.getString('Label')
 ```
 
 **VARIANT** — map Figma enum values to code values:
-```js
+```ts
 const variant = instance.getEnum('Variant', {
   'Primary': 'primary',
   'Secondary': 'secondary',
@@ -148,7 +156,7 @@ const size = instance.getEnum('Size', {
 ```
 
 **BOOLEAN** — simple boolean or mapped to values:
-```js
+```ts
 // Simple boolean
 const disabled = instance.getBoolean('Disabled')
 
@@ -160,7 +168,7 @@ const hasIcon = instance.getBoolean('Has Icon', {
 ```
 
 **INSTANCE_SWAP** — access swappable component instances:
-```js
+```ts
 const icon = instance.getInstanceSwap('Icon')
 let iconCode
 if (icon && icon.hasCodeConnect()) {
@@ -192,7 +200,7 @@ When you need to access children that aren't exposed as component properties:
 
 For multi-level nested components or metadata prop passing between templates, see [advanced-patterns.md](references/advanced-patterns.md).
 
-```js
+```ts
 const icon = instance.getInstanceSwap('Icon')
 let iconSnippet
 if (icon && icon.hasCodeConnect()) {
@@ -207,7 +215,7 @@ export default {
 
 ### Conditional props
 
-```js
+```ts
 const variant = instance.getEnum('Variant', { 'Primary': 'primary', 'Secondary': 'secondary' })
 const disabled = instance.getBoolean('Disabled')
 
@@ -238,7 +246,7 @@ Use the tagged template matching your target language:
 
 ## Step 6: Validate
 
-Read back the `.figma.js` file and review it against the following:
+Read back the `.figma.ts` file and review it against the following:
 
 - **Property coverage** — every Figma property from Step 3 should be accounted for in the template. Flag any that are missing and ask the user if they were intentionally omitted.
 - **Rules and Pitfalls** — check for the common mistakes listed below (string concatenation of template results, missing `hasCodeConnect()` guards, missing `type === 'INSTANCE'` checks, etc.)
@@ -287,7 +295,7 @@ If anything looks uncertain, consult [api.md](references/api.md) for API details
 
 ### Export Structure
 
-```js
+```ts
 export default {
   example: figma.tsx`...`,                      // Required: ResultSection[]
   id: 'component-name',                         // Required: string
@@ -322,7 +330,7 @@ export default {
 6. **Use the correct tagged template** for the target language (`figma.tsx` for React, `figma.html` for HTML, etc.). Avoid `figma.code` when a specific one is available.
 
 7. **Handle multiple template arrays correctly.** When iterating over children, set each result in a separate variable and interpolate them individually — do not use `.map().join()`:
-   ```js
+   ```ts
    // Wrong:
    items.map(n => n.executeTemplate().example).join('\n')
 
@@ -355,13 +363,13 @@ Response includes properties:
 
 **Step 4:** Search codebase → find `Button` component. Read its source to confirm props: `variant`, `size`, `disabled`, `icon`, `children`. Import path: `"primitives"`.
 
-**Step 5:** Create `src/figma/primitives/Button.figma.js`:
+**Step 5:** Create `src/figma/primitives/Button.figma.ts`:
 
-```js
+```ts
 // url=https://figma.com/design/abc123/MyFile?node-id=42-100
 // source=src/components/Button.tsx
 // component=Button
-const figma = require('figma')
+import figma from 'figma'
 const instance = figma.selectedInstance
 
 const label = instance.getString('Label')


### PR DESCRIPTION
Suggesting some changes I think make sense from the Code Connect side - you'll know more than me on if these make sense for MCP though so feel free to push back if anything looks like it wouldn't be an improvement!

- Defaulting to TypeScript for created files - TS support is fairly stable now and we're recommending it in the docs as the default. Seems like a good win for agents and humans as you get type info on all handlers / figma.* utils. Added a prerequisite about having `"types": ["@figma/code-connect/figma-types"]` installed
- Replace `const figma = require('figma')` with `import figma from 'figma'`. This is just aesthetic but we support both and the latter is the more expected pattern
- Removed mention of the different tagged literals (`figma.tsx` etc) and just use `figma.code` in examples. In the docs we recommend people to set `language` in their `figma.config.json` instead, which does the same thing and supports many more languages. The only gotcha is you need to remember to set that in the figma.config.json and not sure if we wanted to wade into instructing the agent to touch the config file or not. Let me know your thoughts!