### PR TITLE
Sync figma-plugin skills to v2.1.30

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.1.27",
+  "version": "2.1.30",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.1.27",
+  "version": "2.1.30",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.1.27",
+  "version": "2.1.30",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.1.27",
+  "version": "2.1.30",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.1.27",
+  "version": "2.1.30",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-use-figjam/SKILL.md
+++ b/skills/figma-use-figjam/SKILL.md
@@ -10,6 +10,29 @@ This skill contains FigJam-specific context for the `use_figma` MCP tool. The [f
 
 **Always pass `skillNames: "figma-use-figjam"` when calling `use_figma` for FigJam operations.** This is a logging parameter used to track skill usage — it does not affect execution.
 
+## Inspecting FigJam Files
+
+**`get_figjam` is the inspection tool for FigJam files.** It returns the full node tree as XML, including IDs of pages, sections, stickies, connectors, and other nodes you need to reference in subsequent `use_figma` calls.
+
+- **Use `get_figjam` upfront** before writing any `use_figma` code that needs to reference existing nodes (page IDs, section IDs, etc.). Don't try to discover IDs by running an inspection script — `console.log` output from `use_figma` is **not returned to the agent** (see [figma-use Critical Rule #4](../figma-use/SKILL.md)). Only the `return` value comes back.
+- **`get_metadata` does NOT work on FigJam files** — it is design-mode only and will fail immediately with "unsupported for FigJam files".
+- **`get_screenshot` requires a valid `nodeId`** — passing an empty nodeId returns "invalid nodeId" error. Get IDs from `get_figjam` first.
+- If you forgot to `return` an ID from a previous `use_figma` call and need it now, call `get_figjam` rather than re-running an inspection script.
+
+## Loading Reference Docs Efficiently
+
+Load only the references your task needs — but when you do need to load multiple, **issue all reads in a single parallel tool-call batch**, not sequentially across turns. For a typical board-creation task, that means a single message containing reads for `plan-board-content` plus the 3-4 specific node-type references you'll use.
+
+## Deferred Tools — Batch-Load Schemas
+
+The Figma MCP tools (`use_figma`, `get_figjam`, `get_screenshot`, `get_metadata`, `create_new_file`, `whoami`) often appear as deferred tools that require `ToolSearch` to load their schemas before they can be called. **Load all schemas in a single `ToolSearch` call** using the `select:` syntax instead of one call per tool:
+
+```
+ToolSearch query="select:use_figma,get_figjam,get_screenshot,get_metadata,create_new_file"
+```
+
+Six sequential `ToolSearch` calls is six round trips before any work happens. One batched call is one round trip.
+
 ## Reference Docs
 
 - [plan-board-content](references/plan-board-content.md) - Read this for any board content request — board template, retro, brainstorm, ice breaker, meeting board, scaffold

--- a/skills/figma-use/SKILL.md
+++ b/skills/figma-use/SKILL.md
@@ -10,6 +10,8 @@ Use the `use_figma` tool to execute JavaScript in Figma files via the Plugin API
 
 **Always pass `skillNames: "figma-use"` when calling `use_figma`.** This is a logging parameter used to track skill usage — it does not affect execution.
 
+**If Figma MCP tools appear as deferred tools, batch-load all their schemas in a single `ToolSearch` call** using the `select:` syntax — e.g. `ToolSearch query="select:use_figma,get_screenshot,get_metadata,create_new_file"`. One round trip beats six.
+
 **If the task involves building or updating a full page, screen, or multi-section layout in Figma from code**, also load [figma-generate-design](../figma-generate-design/SKILL.md). It provides the workflow for discovering design system components via `search_design_system`, importing them, and assembling screens incrementally. Both skills work together: this one for the API rules, that one for the screen-building workflow.
 
 Before anything, load [plugin-api-standalone.index.md](references/plugin-api-standalone.index.md) to understand what is possible. When you are asked to write plugin API code, use this context to grep [plugin-api-standalone.d.ts](references/plugin-api-standalone.d.ts) for relevant types, methods, and properties. This is the definitive source of truth for the API surface. It is a large typings file, so do not load it all at once, grep for relevant sections as needed.


### PR DESCRIPTION
## Summary
- Update the Figma MCP plugin skills to v2.1.30.
- Bump `version` to `2.1.30` in all manifest files: `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.github/plugin/plugin.json`, `gemini-extension.json`, `server.json`
- Skill content updates in `figma-use/SKILL.md` and `figma-use-figjam/SKILL.md` (FigJam reference-loading note tightened; inspection / references / tool-batching guidance improved)

## Test plan
- [ ] CI green on this PR
- [ ] Spot-check `skills/figma-use-figjam/SKILL.md` and `skills/figma-use/SKILL.md` render as expected
- [ ] Verify version `2.1.30` is consistent across the five manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
