### PR TITLE
Sync figma-plugin skills and bump version to 2.2.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.3",
+  "version": "2.2.10",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.3",
+  "version": "2.2.10",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.3",
+  "version": "2.2.10",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.2.3",
+  "version": "2.2.10",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.2.3",
+  "version": "2.2.10",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-generate-design/SKILL.md
+++ b/skills/figma-generate-design/SKILL.md
@@ -94,9 +94,13 @@ Mark resolved components. If all components are resolved, skip 2a-ii and 2a-iii.
 **2a-ii — REQUIRED if unresolved components remain: Inspect existing screens.** Check if the target file already contains screens using the same design system. A single `use_figma` call that walks an existing frame's instances gives you an exact, authoritative component map:
 
 ```js
+// Read-only discovery — skip invisible content inside instances (hidden
+// variants etc.) for the hundreds-of-times-faster findAllWithCriteria.
+figma.skipInvisibleInstanceChildren = true;
+
 const frame = figma.currentPage.findOne(n => n.name === "Existing Screen");
 const uniqueSets = new Map();
-frame.findAll(n => n.type === "INSTANCE").forEach(inst => {
+frame.findAllWithCriteria({ types: ["INSTANCE"] }).forEach(inst => {
   const mc = inst.mainComponent;
   const cs = mc?.parent?.type === "COMPONENT_SET" ? mc.parent : null;
   const key = cs ? cs.key : mc?.key;
@@ -169,22 +173,28 @@ If initial searches return empty, try shorter fragments or different naming conv
 Inspect an existing screen's bound variables for the most authoritative results:
 
 ```js
+// Read-only discovery — skip invisible instance interiors for speed.
+figma.skipInvisibleInstanceChildren = true;
+
 const frame = figma.currentPage.findOne(n => n.name === "Existing Screen");
-const varMap = new Map();
-frame.findAll(() => true).forEach(node => {
-  const bv = node.boundVariables;
-  if (!bv) return;
-  for (const [prop, binding] of Object.entries(bv)) {
-    const bindings = Array.isArray(binding) ? binding : [binding];
-    for (const b of bindings) {
-      if (b?.id && !varMap.has(b.id)) {
-        const v = await figma.variables.getVariableByIdAsync(b.id);
-        if (v) varMap.set(b.id, { name: v.name, id: v.id, key: v.key, type: v.resolvedType, remote: v.remote });
-      }
-    }
-  }
-});
-return [...varMap.values()];
+
+// boundVariables can live on any scene node — enumerating every scene type
+// just to feed findAllWithCriteria is roughly the same as findAll(() => true)
+// and is much noisier in script output.
+const uniqueIds = new Set(
+  frame.findAll(() => true).flatMap(n =>
+    Object.values(n.boundVariables ?? {})
+      .flatMap(b => Array.isArray(b) ? b : [b])
+      .map(b => b?.id)
+      .filter(Boolean)
+  )
+);
+const variables = await Promise.all(
+  [...uniqueIds].map(id => figma.variables.getVariableByIdAsync(id))
+);
+return variables
+  .filter(Boolean)
+  .map(v => ({ name: v.name, id: v.id, key: v.key, type: v.resolvedType, remote: v.remote }));
 ```
 
 For library variables (remote = true), import them by key with `figma.variables.importVariableByKeyAsync(key)`. For local variables, use `figma.variables.getVariableByIdAsync(id)` directly.
@@ -196,9 +206,16 @@ See [variable-patterns.md](../figma-use/references/variable-patterns.md) for bin
 Search for styles using `search_design_system` with `includeStyles: true` and terms like "heading", "body", "shadow", "elevation". Or inspect what an existing screen uses:
 
 ```js
+// Read-only discovery — skip invisible instance interiors for speed.
+figma.skipInvisibleInstanceChildren = true;
+
 const frame = figma.currentPage.findOne(n => n.name === "Existing Screen");
 const styles = { text: new Map(), effect: new Map() };
-frame.findAll(() => true).forEach(node => {
+
+for (const node of frame.findAll(() => true)) {
+  // textStyleId is on TEXT and TEXT_PATH; effectStyleId is on most scene
+  // shape/container types. Use `in` guards to handle both without an
+  // exhaustive type list.
   if ('textStyleId' in node && node.textStyleId) {
     const s = figma.getStyleById(node.textStyleId);
     if (s) styles.text.set(s.id, { name: s.name, id: s.id, key: s.key });
@@ -207,7 +224,8 @@ frame.findAll(() => true).forEach(node => {
     const s = figma.getStyleById(node.effectStyleId);
     if (s) styles.effect.set(s.id, { name: s.name, id: s.id, key: s.key });
   }
-});
+}
+
 return {
   textStyles: [...styles.text.values()],
   effectStyles: [...styles.effect.values()]
@@ -257,17 +275,20 @@ return { success: true, wrapperId: wrapper.id };
 
 ```js
 const createdNodeIds = [];
-const wrapper = await figma.getNodeByIdAsync("WRAPPER_ID_FROM_STEP_3");
 
-// Import design system components by key
-const buttonSet = await figma.importComponentSetByKeyAsync("BUTTON_SET_KEY");
+// Resolve the wrapper and import every design system dependency in parallel.
+// Sequential awaits here serialize N independent IPC round-trips at the top
+// of every section build; one Promise.all is dramatically faster.
+const [wrapper, buttonSet, bgColorVar, spacingVar, shadowStyle] = await Promise.all([
+  figma.getNodeByIdAsync("WRAPPER_ID_FROM_STEP_3"),
+  figma.importComponentSetByKeyAsync("BUTTON_SET_KEY"),
+  figma.variables.importVariableByKeyAsync("BG_COLOR_VAR_KEY"),
+  figma.variables.importVariableByKeyAsync("SPACING_VAR_KEY"),
+  figma.importStyleByKeyAsync("SHADOW_STYLE_KEY"),
+]);
 const primaryButton = buttonSet.children.find(c =>
   c.type === "COMPONENT" && c.name.includes("variant=primary")
 ) || buttonSet.defaultVariant;
-
-// Import design system variables for colors and spacing
-const bgColorVar = await figma.variables.importVariableByKeyAsync("BG_COLOR_VAR_KEY");
-const spacingVar = await figma.variables.importVariableByKeyAsync("SPACING_VAR_KEY");
 
 // Build section frame with variable bindings (not hardcoded values)
 const section = figma.createAutoLayout();
@@ -279,8 +300,7 @@ const bgPaint = figma.variables.setBoundVariableForPaint(
 );
 section.fills = [bgPaint];
 
-// Import and apply text/effect styles
-const shadowStyle = await figma.importStyleByKeyAsync("SHADOW_STYLE_KEY");
+// Apply the effect style imported above
 section.effectStyleId = shadowStyle.id;
 
 // Create component instances inside the section
@@ -305,7 +325,10 @@ Component instances ship with placeholder text ("Title", "Heading", "Button"). U
 For nested instances that expose their own TEXT properties, call `setProperties()` on the nested instance:
 
 ```js
-const nestedHeading = cardInstance.findOne(n => n.type === "INSTANCE" && n.name === "Text Heading");
+// Use the type-indexed criteria for the type filter, then narrow by name.
+const nestedHeading = cardInstance
+  .findAllWithCriteria({ types: ["INSTANCE"] })
+  .find(n => n.name === "Text Heading");
 if (nestedHeading) {
   nestedHeading.setProperties({ "Text#2104:5": "Actual heading from source code" });
 }
@@ -346,18 +369,14 @@ If you ran `generate_figma_design` in parallel (mandatory when the source contai
 
 1. Find all image nodes in the capture output by searching for fills with `type === "IMAGE"`:
    ```js
+   // Read-only image inventory — skip invisible instance interiors for speed.
+   figma.skipInvisibleInstanceChildren = true;
+
    const capture = await figma.getNodeByIdAsync("CAPTURE_NODE_ID");
-   const imageNodes = [];
-   capture.findAll(n => {
-     if (n.fills && Array.isArray(n.fills)) {
-       for (const fill of n.fills) {
-         if (fill.type === "IMAGE") {
-           imageNodes.push({ name: n.name, id: n.id, imageHash: fill.imageHash });
-           return true;
-         }
-       }
-     }
-     return false;
+   const imageNodes = capture.findAll(() => true).flatMap(n => {
+     if (!Array.isArray(n.fills)) return [];
+     const imageFill = n.fills.find(f => f.type === "IMAGE");
+     return imageFill ? [{ name: n.name, id: n.id, imageHash: imageFill.imageHash }] : [];
    });
    return imageNodes;
    ```
@@ -383,11 +402,14 @@ When updating rather than creating from scratch:
 4. Validate with `get_screenshot` after each modification.
 
 ```js
-// Example: Swap a button variant in an existing screen
-const existingButton = await figma.getNodeByIdAsync("EXISTING_BUTTON_INSTANCE_ID");
+// Example: Swap a button variant in an existing screen.
+// Batch the node lookup and component-set import in parallel — they are
+// independent and awaiting them sequentially serializes two IPC round-trips.
+const [existingButton, buttonSet] = await Promise.all([
+  figma.getNodeByIdAsync("EXISTING_BUTTON_INSTANCE_ID"),
+  figma.importComponentSetByKeyAsync("BUTTON_SET_KEY"),
+]);
 if (existingButton && existingButton.type === "INSTANCE") {
-  // Import the updated component
-  const buttonSet = await figma.importComponentSetByKeyAsync("BUTTON_SET_KEY");
   const newVariant = buttonSet.children.find(c =>
     c.name.includes("variant=primary") && c.name.includes("size=lg")
   ) || buttonSet.defaultVariant;

--- a/skills/figma-generate-library/SKILL.md
+++ b/skills/figma-generate-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-generate-library
-description: "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variables/tokens, build component libraries, set up theming (light/dark modes), document foundations, or reconcile gaps between code and Figma. This skill teaches WHAT to build and in WHAT ORDER — it complements the `figma-use` skill which teaches HOW to call the Plugin API. Both skills should be loaded together."
+description: "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variables/tokens, build component libraries, create individual components with proper variant sets and variable bindings, set up theming (light/dark modes), document foundations, or reconcile gaps between code and Figma. Also use when the user asks to create or generate any component in Figma — even a single one — since components require proper variable foundations, variant states, and design token bindings to be production-quality. This skill teaches WHAT to build and in WHAT ORDER — it complements the `figma-use` skill which teaches HOW to call the Plugin API. Both skills should be loaded together."
 disable-model-invocation: false
 ---
 
@@ -78,7 +78,7 @@ Phase 4: INTEGRATION + QA (final pass)
 **Plugin API basics** (from use_figma skill — enforced here too):
 - Use `return` to send data back (auto-serialized). Do NOT wrap in IIFE or call closePlugin.
 - Return ALL created/mutated node IDs in every return value
-- Page context resets each call — always `await figma.setCurrentPageAsync(page)` at start
+- Page context resets each call — always `await figma.setCurrentPageAsync(page)` at start. **Call it at most once per script**: each component or doc page is its own `use_figma` call. Never loop over `figma.root.children` and switch pages inside a mutating script — split that work into one focused call per target page (see [figma-use → gotchas.md → Set current page once per `use_figma` call](../figma-use/references/gotchas.md#set-current-page-once-per-use_figma-call--split-multi-page-work-across-calls))
 - `figma.notify()` throws — never use it
 - Colors are 0–1 range, not 0–255
 - Font MUST be loaded before any text write: `await figma.loadFontAsync({family, style})`. Use `await figma.listAvailableFontsAsync()` to discover available fonts and verify exact style strings — if a load fails, query available fonts to find the correct name or a fallback.

--- a/skills/figma-generate-library/references/code-connect-setup.md
+++ b/skills/figma-generate-library/references/code-connect-setup.md
@@ -158,17 +158,23 @@ variable.setVariableCodeSyntax('iOS', 'Color.bgPrimary');
 **WEB syntax bulk example:**
 
 ```javascript
-// In use_figma — set WEB code syntax on all variables in a collection
+// In use_figma — set WEB code syntax on every variable in matching collections.
+// flatMap all variable IDs across matching collections into a single
+// Promise.all so the lookups run in parallel across collections too — same
+// pattern as `listVariableCollectionsAndVariables` in variable-patterns.md.
+// setVariableCodeSyntax is sync, so the writes don't need to be batched.
 const collections = await figma.variables.getLocalVariableCollectionsAsync();
-for (const coll of collections) {
-  if (coll.name !== 'Color') continue;
-  for (const varId of coll.variableIds) {
-    const v = await figma.variables.getVariableByIdAsync(varId);
-    if (!v) continue;
-    // Derive: "color/bg/primary" → "var(--color-bg-primary)"
-    const cssName = 'var(--' + v.name.toLowerCase().replace(/\//g, '-').replace(/\s+/g, '-') + ')';
-    v.setVariableCodeSyntax('WEB', cssName);
-  }
+const ids = collections
+  .filter(c => c.name === 'Color')
+  .flatMap(c => c.variableIds);
+const vars = await Promise.all(
+  ids.map(id => figma.variables.getVariableByIdAsync(id))
+);
+for (const v of vars) {
+  if (!v) continue;
+  // Derive: "color/bg/primary" → "var(--color-bg-primary)"
+  const cssName = 'var(--' + v.name.toLowerCase().replace(/\//g, '-').replace(/\s+/g, '-') + ')';
+  v.setVariableCodeSyntax('WEB', cssName);
 }
 ```
 

--- a/skills/figma-generate-library/references/component-creation.md
+++ b/skills/figma-generate-library/references/component-creation.md
@@ -540,7 +540,7 @@ svgNode.remove();
 
 // Bind the icon fill to a color variable (so it respects themes)
 // Find vector children and bind their fills
-iconComp.findAll(n => n.type === 'VECTOR').forEach(vec => {
+iconComp.findAllWithCriteria({ types: ['VECTOR'] }).forEach(vec => {
   // For stroke-based icons:
   if (vec.strokes.length > 0) {
     const strokePaint = figma.variables.setBoundVariableForPaint(
@@ -619,9 +619,11 @@ const key   = node.getSharedPluginData('dsb', 'key');
 **Idempotency check before creating:** before creating a node, scan the current page for an existing node with the same `key`:
 
 ```javascript
-const existing = figma.currentPage.findAll(n =>
-  n.getSharedPluginData('dsb', 'key') === 'componentset/button'
-);
+// Indexed sharedPluginData lookup — the engine only visits nodes that
+// actually carry the dsb namespace key, not every node on the page.
+const existing = figma.currentPage
+  .findAllWithCriteria({ sharedPluginData: { namespace: 'dsb', keys: ['key'] } })
+  .filter(n => n.getSharedPluginData('dsb', 'key') === 'componentset/button');
 if (existing.length > 0) {
   // Skip creation — already done. Return existing node's ID.
   return { componentSetId: existing[0].id };
@@ -785,8 +787,11 @@ const PAGE_ID = 'PAGE_ID_FROM_STATE';
 const page = await figma.getNodeByIdAsync(PAGE_ID);
 await figma.setCurrentPageAsync(page);
 
-// Idempotency check
-const existing = page.findAll(n => n.getSharedPluginData('dsb', 'key') === 'doc/button');
+// Idempotency check — use the sharedPluginData index instead of a per-node
+// findAll callback.
+const existing = page
+  .findAllWithCriteria({ sharedPluginData: { namespace: 'dsb', keys: ['key'] } })
+  .filter(n => n.getSharedPluginData('dsb', 'key') === 'doc/button');
 if (existing.length > 0) {
   return { docFrameId: existing[0].id };
 }
@@ -861,11 +866,14 @@ await figma.setCurrentPageAsync(page);
 
 const base = await figma.getNodeByIdAsync(BASE_ID);
 
-// Load all variables
+// Load all variables in parallel — sequential awaits in the loop would
+// serialize one IPC round-trip per variable.
+const varEntries = Object.entries(VAR);
+const fetched = await Promise.all(
+  varEntries.map(([, id]) => figma.variables.getVariableByIdAsync(id))
+);
 const vars = {};
-for (const [k, v] of Object.entries(VAR)) {
-  vars[k] = await figma.variables.getVariableByIdAsync(v);
-}
+varEntries.forEach(([k], i) => { vars[k] = fetched[i]; });
 
 const axes = {
   Size:  ['Small', 'Medium', 'Large'],

--- a/skills/figma-generate-library/references/discovery-phase.md
+++ b/skills/figma-generate-library/references/discovery-phase.md
@@ -240,9 +240,12 @@ Interpret: check if variables use `ALL_SCOPES` (bad), check naming convention (s
 ### List Component Sets with Properties
 
 ```javascript
+// Read-only inspection — skip invisible instance interiors for speed.
+figma.skipInvisibleInstanceChildren = true;
+
 // To inspect a specific page, switch to it first:
 // await figma.setCurrentPageAsync(targetPage);
-const componentSets = figma.currentPage.findAll(n => n.type === 'COMPONENT_SET');
+const componentSets = figma.currentPage.findAllWithCriteria({ types: ['COMPONENT_SET'] });
 const result = componentSets.map(cs => ({
   id: cs.id,
   name: cs.name,
@@ -257,7 +260,7 @@ const result = componentSets.map(cs => ({
 return { componentSets: result, count: result.length };
 ```
 
-Note: to search ALL pages, iterate `figma.root.children` and `setCurrentPageAsync` for each.
+Note: to search ALL pages, **do not iterate `figma.root.children` and `setCurrentPageAsync` inside one script.** Run a cheap discovery call first (`figma.root.children.map(p => ({id: p.id, name: p.name}))`), then in the next assistant turn emit **one `use_figma` per page in parallel** — a single message with N tool-use blocks — each setting `currentPage` once. See [figma-use → gotchas.md → Set current page once per `use_figma` call](../../figma-use/references/gotchas.md#set-current-page-once-per-use_figma-call--split-multi-page-work-into-parallel-calls).
 
 ### List All Styles
 

--- a/skills/figma-generate-library/references/documentation-creation.md
+++ b/skills/figma-generate-library/references/documentation-creation.md
@@ -34,9 +34,13 @@ async function createCoverPage(systemName, tagline, version, primaryColorVar) {
   page.name = 'Cover';
   await figma.setCurrentPageAsync(page);
 
-  await figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Medium' });
+  // Batch the font loads — sequential awaits would serialize three IPC
+  // round-trips that can run in parallel.
+  await Promise.all([
+    figma.loadFontAsync({ family: 'Inter', style: 'Bold' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Regular' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Medium' }),
+  ]);
 
   const frame = figma.createAutoLayout('VERTICAL');
   frame.name = 'Cover';
@@ -111,9 +115,13 @@ async function createFoundationsPage() {
   page.name = 'Foundations';
   await figma.setCurrentPageAsync(page);
 
-  await figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Medium' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+  // Batch the font loads — sequential awaits would serialize three IPC
+  // round-trips that can run in parallel.
+  await Promise.all([
+    figma.loadFontAsync({ family: 'Inter', style: 'Bold' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Medium' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Regular' }),
+  ]);
 
   // Root scroll frame
   const root = figma.createAutoLayout('VERTICAL');
@@ -211,8 +219,10 @@ async function createColorSwatch(parent, varName, variable) {
  * @param {Variable[]} semanticVars - Variables from the semantic Color collection.
  */
 async function createColorSection(root, primitiveVars, semanticVars) {
-  await figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+  await Promise.all([
+    figma.loadFontAsync({ family: 'Inter', style: 'Bold' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Regular' }),
+  ]);
 
   // Section container
   const section = figma.createAutoLayout('VERTICAL');
@@ -307,9 +317,11 @@ Typography specimens show each text style rendered at its actual size with a sam
  * @returns {FrameNode} The specimen row frame.
  */
 async function createTypeSpecimen(parent, styleName, fontFamily, fontStyle, fontSize, lineHeight) {
-  await figma.loadFontAsync({ family: fontFamily, style: fontStyle });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Medium' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+  await Promise.all([
+    figma.loadFontAsync({ family: fontFamily, style: fontStyle }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Medium' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Regular' }),
+  ]);
 
   const row = figma.createAutoLayout('VERTICAL');
   row.name = `Type/${styleName}`;
@@ -499,8 +511,10 @@ Elevation documentation shows cards with progressively stronger drop shadows, la
  * @param {DropShadowEffect[]} effects - Array of Figma effect objects.
  */
 async function createShadowCard(parent, name, effects) {
-  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Medium' });
+  await Promise.all([
+    figma.loadFontAsync({ family: 'Inter', style: 'Regular' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Medium' }),
+  ]);
 
   const card = figma.createAutoLayout('VERTICAL');
   card.name = `ShadowCard/${name}`;
@@ -610,8 +624,10 @@ Border radius documentation shows rectangles at each corner radius value, labele
  * @param {Variable} [variable] - Optional Figma Variable to bind corner radius.
  */
 async function createRadiusCard(parent, name, value, variable) {
-  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Medium' });
+  await Promise.all([
+    figma.loadFontAsync({ family: 'Inter', style: 'Regular' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Medium' }),
+  ]);
 
   const wrapper = figma.createAutoLayout('VERTICAL');
   wrapper.name = `Radius/${name}`;
@@ -725,8 +741,10 @@ Each component page should include a documentation frame directly on the canvas,
  * @returns {FrameNode} The documentation frame.
  */
 async function createComponentDocFrame(page, componentName, description, usageNotes) {
-  await figma.loadFontAsync({ family: 'Inter', style: 'Bold' });
-  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+  await Promise.all([
+    figma.loadFontAsync({ family: 'Inter', style: 'Bold' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Regular' }),
+  ]);
 
   const doc = figma.createAutoLayout('VERTICAL');
   doc.name = '_Doc';

--- a/skills/figma-generate-library/references/error-recovery.md
+++ b/skills/figma-generate-library/references/error-recovery.md
@@ -80,9 +80,14 @@ const skipped = [];
 for (const page of pagesToSearch) {
   await figma.setCurrentPageAsync(page);
 
-  const orphans = page.findAll(node => {
-    const runId = node.getSharedPluginData('dsb', 'run_id');
-    if (runId !== TARGET_RUN_ID) return false;
+  // Use the sharedPluginData index instead of findAll + getSharedPluginData
+  // on every node. The engine narrows to nodes that actually carry the
+  // namespace/keys before any JS callback runs.
+  const candidates = page.findAllWithCriteria({
+    sharedPluginData: { namespace: 'dsb', keys: ['run_id'] },
+  });
+  const orphans = candidates.filter(node => {
+    if (node.getSharedPluginData('dsb', 'run_id') !== TARGET_RUN_ID) return false;
     if (TARGET_PHASE && node.getSharedPluginData('dsb', 'phase') !== TARGET_PHASE) return false;
     return true;
   });
@@ -199,9 +204,13 @@ const RUN_ID = 'ds-build-2024-001';
 const page = await figma.getNodeByIdAsync(PAGE_ID);
 await figma.setCurrentPageAsync(page);
 
-const existing = page.findAll(n =>
-  n.type === 'COMPONENT_SET' && n.getSharedPluginData('dsb', 'key') === KEY
-);
+// Indexed lookup: only COMPONENT_SET nodes with the dsb namespace + key.
+const existing = page
+  .findAllWithCriteria({
+    types: ['COMPONENT_SET'],
+    sharedPluginData: { namespace: 'dsb', keys: ['key'] },
+  })
+  .filter(n => n.getSharedPluginData('dsb', 'key') === KEY);
 
 if (existing.length > 0) {
   return {
@@ -307,10 +316,17 @@ const toVerify = {
   'button-componentset': '4567:1',
 };
 
+// Batch the lookups — awaiting getNodeByIdAsync per entry serializes the
+// round-trips. Resolve them all in parallel with Promise.all, then walk the
+// results.
+const entries = Object.entries(toVerify);
+const nodes = await Promise.all(
+  entries.map(([, id]) => figma.getNodeByIdAsync(id).catch(() => null))
+);
 const results = {};
-for (const [label, id] of Object.entries(toVerify)) {
-  const node = await figma.getNodeByIdAsync(id)
-    .catch(() => null);
+for (let i = 0; i < entries.length; i++) {
+  const [label] = entries[i];
+  const node = nodes[i];
   results[label] = node ? { found: true, name: node.name } : { found: false };
 }
 
@@ -326,6 +342,10 @@ If any entity is missing, treat the phase that created it as incomplete and re-r
 ### Step 1: Inspect the file for `run_id` tags
 
 ```javascript
+// Read-only resume inventory — dsb-tagged nodes are top-level user-created
+// frames, never inside instances, so skip invisible instance interiors.
+figma.skipInvisibleInstanceChildren = true;
+
 const TARGET_RUN_ID = 'ds-build-2024-001';
 const inventory = { pages: [], variables: [], componentSets: [], frames: [] };
 
@@ -347,7 +367,11 @@ for (const v of allVars) {
 // Scan all component sets and frames on each page
 for (const page of figma.root.children) {
   await figma.setCurrentPageAsync(page);
-  const nodes = page.findAll(n => n.getSharedPluginData('dsb', 'run_id') === TARGET_RUN_ID);
+  // Indexed sharedPluginData lookup — much faster than findAll + getSharedPluginData per node.
+  const candidates = page.findAllWithCriteria({
+    sharedPluginData: { namespace: 'dsb', keys: ['run_id'] },
+  });
+  const nodes = candidates.filter(n => n.getSharedPluginData('dsb', 'run_id') === TARGET_RUN_ID);
   for (const n of nodes) {
     if (n.type === 'COMPONENT_SET') {
       inventory.componentSets.push({ id: n.id, name: n.name, key: n.getSharedPluginData('dsb', 'key') });

--- a/skills/figma-generate-library/scripts/bindVariablesToComponent.js
+++ b/skills/figma-generate-library/scripts/bindVariablesToComponent.js
@@ -32,59 +32,8 @@ async function bindVariablesToComponent(component, bindings) {
     return { mutatedNodeIds }
   }
 
-  // --- Fills ---
-  if (bindings.fills) {
-    const fillVar = await figma.variables.getVariableByIdAsync(bindings.fills)
-    if (fillVar) {
-      const existingFills = component.fills
-      if (Array.isArray(existingFills) && existingFills.length > 0) {
-        // Bind the color of the first fill to the variable
-        const boundFill = figma.variables.setBoundVariableForPaint(
-          existingFills[0],
-          'color',
-          fillVar,
-        )
-        component.fills = [boundFill, ...existingFills.slice(1)]
-      } else {
-        // No existing fill — create a solid fill bound to the variable
-        const boundFill = figma.variables.setBoundVariableForPaint(
-          { type: 'SOLID', color: { r: 0.5, g: 0.5, b: 0.5 } },
-          'color',
-          fillVar,
-        )
-        component.fills = [boundFill]
-      }
-      mutatedNodeIds.push(component.id)
-    }
-  }
-
-  // --- Strokes ---
-  if (bindings.strokes) {
-    const strokeVar = await figma.variables.getVariableByIdAsync(bindings.strokes)
-    if (strokeVar) {
-      const existingStrokes = component.strokes
-      if (Array.isArray(existingStrokes) && existingStrokes.length > 0) {
-        const boundStroke = figma.variables.setBoundVariableForPaint(
-          existingStrokes[0],
-          'color',
-          strokeVar,
-        )
-        component.strokes = [boundStroke, ...existingStrokes.slice(1)]
-      } else {
-        const boundStroke = figma.variables.setBoundVariableForPaint(
-          { type: 'SOLID', color: { r: 0.5, g: 0.5, b: 0.5 } },
-          'color',
-          strokeVar,
-        )
-        component.strokes = [boundStroke]
-      }
-      if (!mutatedNodeIds.includes(component.id)) {
-        mutatedNodeIds.push(component.id)
-      }
-    }
-  }
-
-  // --- Spacing properties (FLOAT variables bound via setBoundVariable) ---
+  // Batch every getVariableByIdAsync call upfront in a single Promise.all rather
+  // than awaiting per-property — the lookups are independent and IPC-bound.
   const floatBindings = [
     ['paddingTop', 'paddingTop'],
     ['paddingBottom', 'paddingBottom'],
@@ -94,15 +43,75 @@ async function bindVariablesToComponent(component, bindings) {
     ['cornerRadius', 'cornerRadius'],
   ]
 
+  const requestedIds = []
+  if (bindings.fills) requestedIds.push(['fills', bindings.fills])
+  if (bindings.strokes) requestedIds.push(['strokes', bindings.strokes])
+  for (const [bindingKey] of floatBindings) {
+    if (bindings[bindingKey]) requestedIds.push([bindingKey, bindings[bindingKey]])
+  }
+
+  const resolved = await Promise.all(
+    requestedIds.map(([, id]) => figma.variables.getVariableByIdAsync(id)),
+  )
+  const varByKey = {}
+  for (let i = 0; i < requestedIds.length; i++) {
+    varByKey[requestedIds[i][0]] = resolved[i]
+  }
+
+  const markMutated = () => {
+    if (!mutatedNodeIds.includes(component.id)) {
+      mutatedNodeIds.push(component.id)
+    }
+  }
+
+  // --- Fills ---
+  const fillVar = varByKey.fills
+  if (fillVar) {
+    const existingFills = component.fills
+    if (Array.isArray(existingFills) && existingFills.length > 0) {
+      // Bind the color of the first fill to the variable
+      const boundFill = figma.variables.setBoundVariableForPaint(existingFills[0], 'color', fillVar)
+      component.fills = [boundFill, ...existingFills.slice(1)]
+    } else {
+      // No existing fill — create a solid fill bound to the variable
+      const boundFill = figma.variables.setBoundVariableForPaint(
+        { type: 'SOLID', color: { r: 0.5, g: 0.5, b: 0.5 } },
+        'color',
+        fillVar,
+      )
+      component.fills = [boundFill]
+    }
+    markMutated()
+  }
+
+  // --- Strokes ---
+  const strokeVar = varByKey.strokes
+  if (strokeVar) {
+    const existingStrokes = component.strokes
+    if (Array.isArray(existingStrokes) && existingStrokes.length > 0) {
+      const boundStroke = figma.variables.setBoundVariableForPaint(
+        existingStrokes[0],
+        'color',
+        strokeVar,
+      )
+      component.strokes = [boundStroke, ...existingStrokes.slice(1)]
+    } else {
+      const boundStroke = figma.variables.setBoundVariableForPaint(
+        { type: 'SOLID', color: { r: 0.5, g: 0.5, b: 0.5 } },
+        'color',
+        strokeVar,
+      )
+      component.strokes = [boundStroke]
+    }
+    markMutated()
+  }
+
+  // --- Spacing properties (FLOAT variables bound via setBoundVariable) ---
   for (const [bindingKey, figmaProp] of floatBindings) {
-    if (bindings[bindingKey]) {
-      const variable = await figma.variables.getVariableByIdAsync(bindings[bindingKey])
-      if (variable) {
-        component.setBoundVariable(figmaProp, variable)
-        if (!mutatedNodeIds.includes(component.id)) {
-          mutatedNodeIds.push(component.id)
-        }
-      }
+    const variable = varByKey[bindingKey]
+    if (variable) {
+      component.setBoundVariable(figmaProp, variable)
+      markMutated()
     }
   }
 

--- a/skills/figma-generate-library/scripts/cleanupOrphans.js
+++ b/skills/figma-generate-library/scripts/cleanupOrphans.js
@@ -24,6 +24,11 @@ async function cleanupOrphans(runId) {
     throw new Error('cleanupOrphans: runId is required.')
   }
 
+  // dsb-tagged nodes are top-level user-created frames, never inside
+  // component instances — skip invisible instance interiors to speed up the
+  // pluginData scan dramatically on large files.
+  figma.skipInvisibleInstanceChildren = true
+
   const removedIds = []
   const originalPage = figma.currentPage
 
@@ -40,11 +45,20 @@ async function cleanupOrphans(runId) {
     // Traverse all nodes on this page
     await figma.setCurrentPageAsync(page)
 
-    const nodesToRemove = []
-    page.findAll((node) => {
-      if (node.getPluginData('dsb_run_id') === runId) {
-        nodesToRemove.push(node)
-        return false // Don't descend — removing the parent removes its children
+    // Use the pluginData index to find candidates, then keep only those whose
+    // run_id matches. Much faster than findAll + getPluginData on every node.
+    const candidates = page.findAllWithCriteria({
+      pluginData: { keys: ['dsb_run_id'] },
+    })
+    const tagged = candidates.filter((node) => node.getPluginData('dsb_run_id') === runId)
+    // Drop descendants of already-collected nodes (removing the parent removes
+    // its children, so we only need the topmost match in each chain).
+    const taggedSet = new Set(tagged)
+    const nodesToRemove = tagged.filter((node) => {
+      let p = node.parent
+      while (p) {
+        if (taggedSet.has(p)) return false
+        p = p.parent
       }
       return true
     })

--- a/skills/figma-generate-library/scripts/createDocumentationPage.js
+++ b/skills/figma-generate-library/scripts/createDocumentationPage.js
@@ -45,9 +45,11 @@ async function createDocumentationPage(pageName, config, runId) {
       )
     }
   }
-  await figma.loadFontAsync({ family: 'Inter', style: 'Bold' })
-  await figma.loadFontAsync({ family: 'Inter', style: 'Regular' })
-  await figma.loadFontAsync({ family: 'Inter', style: 'Medium' })
+  await Promise.all([
+    figma.loadFontAsync({ family: 'Inter', style: 'Bold' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Regular' }),
+    figma.loadFontAsync({ family: 'Inter', style: 'Medium' }),
+  ])
 
   // Create and activate the page
   const page = figma.createPage()

--- a/skills/figma-generate-library/scripts/inspectFileStructure.js
+++ b/skills/figma-generate-library/scripts/inspectFileStructure.js
@@ -25,6 +25,10 @@
  * }>}
  */
 async function inspectFileStructure() {
+  // Read-only inspection — skip invisible content inside instances for a
+  // hundreds-of-times-faster findAllWithCriteria on large libraries.
+  figma.skipInvisibleInstanceChildren = true
+
   const result = {
     pages: [],
     variableCollections: [],
@@ -66,29 +70,28 @@ async function inspectFileStructure() {
   for (const page of figma.root.children) {
     await figma.setCurrentPageAsync(page)
 
-    const componentSetsOnPage = page.findAllWithCriteria({ types: ['COMPONENT_SET'] })
-    for (const cs of componentSetsOnPage) {
-      result.componentSets.push({
-        id: cs.id,
-        name: cs.name,
-        variantCount: cs.children.length,
-        pageId: page.id,
-        pageName: page.name,
-      })
-    }
-
-    // Also capture standalone components (not inside a component set)
-    const standaloneComponents = page
-      .findAllWithCriteria({ types: ['COMPONENT'] })
-      .filter((c) => c.parent && c.parent.type !== 'COMPONENT_SET')
-    for (const comp of standaloneComponents) {
-      result.componentSets.push({
-        id: comp.id,
-        name: comp.name,
-        variantCount: 1,
-        pageId: page.id,
-        pageName: page.name,
-      })
+    // findAllWithCriteria.types accepts an array — one indexed scan returns
+    // both COMPONENT_SET and standalone COMPONENT nodes.
+    const found = page.findAllWithCriteria({ types: ['COMPONENT_SET', 'COMPONENT'] })
+    for (const node of found) {
+      if (node.type === 'COMPONENT_SET') {
+        result.componentSets.push({
+          id: node.id,
+          name: node.name,
+          variantCount: node.children.length,
+          pageId: page.id,
+          pageName: page.name,
+        })
+      } else if (node.parent && node.parent.type !== 'COMPONENT_SET') {
+        // Standalone component (not a variant inside a COMPONENT_SET)
+        result.componentSets.push({
+          id: node.id,
+          name: node.name,
+          variantCount: 1,
+          pageId: page.id,
+          pageName: page.name,
+        })
+      }
     }
   }
 

--- a/skills/figma-generate-library/scripts/rehydrateState.js
+++ b/skills/figma-generate-library/scripts/rehydrateState.js
@@ -9,6 +9,11 @@
  * @returns {{ runId: string, taggedNodes: Object<string, {nodeId: string, type: string, name: string, phase: string}>, variableCollections: Array, variables: Array, styles: Array }}
  */
 async function rehydrateState(runId) {
+  // Read-only inventory — dsb-tagged nodes are user-created top-level frames,
+  // never inside instances, so skip invisible instance interiors for the
+  // hundreds-of-times-faster findAllWithCriteria.
+  figma.skipInvisibleInstanceChildren = true
+
   const taggedNodes = {}
   const variableCollections = []
   const variables = []
@@ -30,8 +35,13 @@ async function rehydrateState(runId) {
       }
     }
 
-    // Scan all descendants
-    page.findAll((node) => {
+    // Use findAllWithCriteria with the pluginData index — drastically faster
+    // than findAll + getPluginData on every node, because the engine narrows
+    // to nodes that actually have these keys.
+    const tagged = page.findAllWithCriteria({
+      pluginData: { keys: ['dsb_key', 'dsb_run_id'] },
+    })
+    for (const node of tagged) {
       const nodeRunId = node.getPluginData('dsb_run_id')
       const nodeKey = node.getPluginData('dsb_key')
       if (nodeKey && (!runId || nodeRunId === runId)) {
@@ -42,8 +52,7 @@ async function rehydrateState(runId) {
           phase: node.getPluginData('dsb_phase') || 'unknown',
         }
       }
-      return false // don't collect, just scan
-    })
+    }
   }
 
   // Inventory variable collections (variables don't support pluginData — use name-based lookup)

--- a/skills/figma-use-figjam/references/batch-modify.md
+++ b/skills/figma-use-figjam/references/batch-modify.md
@@ -28,14 +28,15 @@ figma.closePlugin()
 
 ### 2. Skip Invisible Instance Children
 
-For large files with many component instances, this significantly speeds up traversal.
+For large files with many component instances, this significantly speeds up traversal — up to hundreds of times faster on `findAllWithCriteria`. See [figma-use → gotchas.md → Set figma.skipInvisibleInstanceChildren](../../figma-use/references/gotchas.md#set-figmaskipinvisibleinstancechildren--true-for-read-only-traversal) for the full rule and caveats. Don't enable it when you specifically need to read or mutate invisible content inside instances.
 
 ```javascript
 // Enable at the start of your script
 figma.skipInvisibleInstanceChildren = true
 
-// Now findAll/findOne will skip hidden content inside instances
-const visibleText = figma.currentPage.findAll((n) => n.type === 'TEXT')
+// Now findAll / findOne / findAllWithCriteria skip hidden content inside
+// instances. Combine with the type-indexed lookup from Tip 1 for max speed.
+const visibleText = figma.currentPage.findAllWithCriteria({ types: ['TEXT'] })
 
 figma.closePlugin()
 ```
@@ -45,13 +46,13 @@ figma.closePlugin()
 Search within a specific node rather than the entire page.
 
 ```javascript
-// ✅ FAST - Search within specific frame
+// ✅ FAST - Search within specific frame, using indexed type lookup
 const frame = await figma.getNodeByIdAsync('123:456')
-if (frame && 'findAll' in frame) {
-  const textInFrame = frame.findAll((n) => n.type === 'TEXT')
+if (frame && 'findAllWithCriteria' in frame) {
+  const textInFrame = frame.findAllWithCriteria({ types: ['TEXT'] })
 }
 
-// ❌ SLOWER - Search entire page
+// ❌ SLOWER - Whole-page predicate scan
 const allText = figma.currentPage.findAll((n) => n.type === 'TEXT')
 
 figma.closePlugin()
@@ -251,11 +252,12 @@ figma.closePlugin()
 ### Content-Based Naming (Name from Text Content)
 
 ```javascript
-const frames = figma.currentPage.findAll((n) => n.type === 'FRAME' && 'children' in n)
+const frames = figma.currentPage.findAllWithCriteria({ types: ['FRAME'] })
 
 let renamed = 0
 for (const frame of frames) {
-  const heading = frame.findOne((n) => n.type === 'TEXT')
+  // Use the type-indexed criteria for type-based searches; take the first match.
+  const heading = frame.findAllWithCriteria({ types: ['TEXT'] })[0]
   if (heading) {
     frame.name = heading.characters.slice(0, 40)
     renamed++
@@ -285,9 +287,10 @@ figma.closePlugin()
 Figma groups layers in the panel by `/` in names (e.g., `icons/arrow`, `icons/check`).
 
 ```javascript
-const icons = figma.currentPage.findAll(
-  (n) => n.type === 'INSTANCE' && n.name.toLowerCase().includes('icon'),
-)
+// Use the type-indexed criteria for the type filter, then narrow by name.
+const icons = figma.currentPage
+  .findAllWithCriteria({ types: ['INSTANCE'] })
+  .filter((n) => n.name.toLowerCase().includes('icon'))
 
 for (const icon of icons) {
   if (!icon.name.startsWith('icons/')) {

--- a/skills/figma-use-figjam/references/create-code-block.md
+++ b/skills/figma-use-figjam/references/create-code-block.md
@@ -65,7 +65,10 @@ return { id: cb.id }
 To place a code block inside a FigJam section, append it to the section instead of the page:
 
 ```javascript
-const section = figma.currentPage.findOne((n) => n.type === 'SECTION' && n.name === 'My Section')
+// Use the type-indexed criteria for the type filter, then narrow by name.
+const section = figma.currentPage
+  .findAllWithCriteria({ types: ['SECTION'] })
+  .find((n) => n.name === 'My Section')
 if (!section) throw new Error('Section not found')
 
 const cb = figma.createCodeBlock()

--- a/skills/figma-use-figjam/references/create-connector.md
+++ b/skills/figma-use-figjam/references/create-connector.md
@@ -262,10 +262,14 @@ const spacing = 80
 const totalWidth = steps.length * shapeW + (steps.length - 1) * spacing
 const startX = 0
 
+// Every shape uses the same default font — load once before the loop
+// rather than awaiting per-iteration.
+const probe = figma.createShapeWithText()
+await figma.loadFontAsync(probe.text.fontName)
+probe.remove()
 const nodes = []
 for (let i = 0; i < steps.length; i++) {
   const shape = figma.createShapeWithText()
-  await figma.loadFontAsync(shape.text.fontName)
   shape.text.characters = steps[i]
   shape.resize(shapeW, shapeH)
   shape.fills = [{ type: 'SOLID', color: preset.fill }]

--- a/skills/figma-use-figjam/references/create-label.md
+++ b/skills/figma-use-figjam/references/create-label.md
@@ -102,12 +102,16 @@ const size = 48
 const spacing = 16
 const labelLocation = { x: 100, y: 100 }
 
-// Pass 1: create all labels
+// Pass 1: create all labels.
+// All labels share the same default font — load once before the loop instead
+// of awaiting per-iteration.
+const probe = figma.createShapeWithText()
+await figma.loadFontAsync(probe.text.fontName)
+probe.remove()
 const labels = []
 for (let i = 1; i <= count; i++) {
   const label = figma.createShapeWithText()
   label.shapeType = 'ELLIPSE'
-  await figma.loadFontAsync(label.text.fontName)
   label.text.characters = String(i)
   label.resize(size, size)
   label.text.fontSize = 20
@@ -143,12 +147,16 @@ const size = 48
 const spacing = 16
 const labelLocation = { x: 100, y: 100 }
 
-// Pass 1: create all labels
+// Pass 1: create all labels.
+// All labels share the same default font — load once before the loop instead
+// of awaiting per-iteration.
+const probe = figma.createShapeWithText()
+await figma.loadFontAsync(probe.text.fontName)
+probe.remove()
 const labels = []
 for (const letter of letters) {
   const label = figma.createShapeWithText()
   label.shapeType = 'ELLIPSE'
-  await figma.loadFontAsync(label.text.fontName)
   label.text.characters = letter
   label.resize(size, size)
   label.text.fontSize = 20
@@ -211,12 +219,23 @@ const annotations = [
 // targetNodes: the nodes being annotated, one per annotation
 // (derive from node IDs passed in the user message)
 
+// Pre-load the label and sticky default fonts in parallel — both fonts are
+// the same for every iteration, so awaiting inside the loop would needlessly
+// serialize the work.
+const labelProbe = figma.createShapeWithText()
+const stickyProbe = figma.createSticky()
+await Promise.all([
+  figma.loadFontAsync(labelProbe.text.fontName),
+  figma.loadFontAsync(stickyProbe.text.fontName),
+])
+labelProbe.remove()
+stickyProbe.remove()
+
 // Pass 1: create labels and stickies
 const pairs = []
 for (const item of annotations) {
   const label = figma.createShapeWithText()
   label.shapeType = 'ELLIPSE'
-  await figma.loadFontAsync(label.text.fontName)
   label.text.characters = item.number
   label.resize(48, 48)
   label.text.fontSize = 20
@@ -225,7 +244,6 @@ for (const item of annotations) {
   label.text.fills = [{ type: 'SOLID', color: PRESET_BLUE.text }]
 
   const sticky = figma.createSticky()
-  await figma.loadFontAsync(sticky.text.fontName)
   sticky.text.characters = `${item.number}. ${item.text}`
 
   pairs.push({ label, sticky })

--- a/skills/figma-use-figjam/references/create-shape-with-text.md
+++ b/skills/figma-use-figjam/references/create-shape-with-text.md
@@ -42,11 +42,15 @@ Available shape types:
 
 ```javascript
 const types = ['SQUARE', 'DIAMOND', 'ELLIPSE', 'ROUNDED_RECTANGLE']
+// All shapes share the same default font — load once before the loop instead
+// of awaiting per-iteration.
+const probe = figma.createShapeWithText()
+await figma.loadFontAsync(probe.text.fontName)
+probe.remove()
 const shapes = []
 for (const type of types) {
   const s = figma.createShapeWithText()
   s.shapeType = type
-  await figma.loadFontAsync(s.text.fontName)
   s.text.characters = type
   shapes.push(s)
 }
@@ -311,11 +315,15 @@ const sizes = items.map((item) => fitShapeToText(item.label, item.type))
 const totalWidth = sizes.reduce((sum, s) => sum + s.w, 0) + (items.length - 1) * spacing
 let curX = 0
 
+// All shapes share the same default font — load once before the loop
+// instead of awaiting per-iteration.
+const probe = figma.createShapeWithText()
+await figma.loadFontAsync(probe.text.fontName)
+probe.remove()
 for (let i = 0; i < items.length; i++) {
   const size = sizes[i]
   const shape = figma.createShapeWithText()
   shape.shapeType = items[i].type
-  await figma.loadFontAsync(shape.text.fontName)
   shape.text.characters = items[i].label
   shape.resize(size.w, size.h)
   const preset = items[i].color

--- a/skills/figma-use-figjam/references/create-sticky.md
+++ b/skills/figma-use-figjam/references/create-sticky.md
@@ -180,11 +180,15 @@ const colors = [
 ]
 const spacing = 64
 
-// Pass 1: Create all stickies and set content
+// Pass 1: Create all stickies and set content.
+// Every sticky uses the same default font, so load it once before the loop
+// rather than awaiting per-iteration.
+const probe = figma.createSticky()
+await figma.loadFontAsync(probe.text.fontName)
+probe.remove()
 const stickies = []
 for (let i = 0; i < labels.length; i++) {
   const sticky = figma.createSticky()
-  await figma.loadFontAsync(sticky.text.fontName)
   sticky.text.characters = labels[i]
   sticky.fills = [{ type: 'SOLID', color: colors[i % colors.length] }]
   stickies.push(sticky)
@@ -212,11 +216,15 @@ const items = ['Task A', 'Task B', 'Task C', 'Task D', 'Task E', 'Task F']
 const cols = 3
 const spacing = 64
 
-// Pass 1: Create all stickies and set content
+// Pass 1: Create all stickies and set content.
+// All stickies share the same default font — load once outside the loop
+// instead of awaiting per-iteration.
+const probe = figma.createSticky()
+await figma.loadFontAsync(probe.text.fontName)
+probe.remove()
 const stickies = []
 for (let i = 0; i < items.length; i++) {
   const sticky = figma.createSticky()
-  await figma.loadFontAsync(sticky.text.fontName)
   sticky.text.characters = items[i]
   sticky.fills = [{ type: 'SOLID', color: h(0xff, 0xe2, 0x99) }] // Yellow #FFE299
   stickies.push(sticky)

--- a/skills/figma-use-figjam/references/create-text.md
+++ b/skills/figma-use-figjam/references/create-text.md
@@ -370,11 +370,15 @@ const parent = branchNode.parent
 const newTopics = ['Topic A', 'Topic B', 'Topic C']
 const Y_SPACING = 40
 
-// Measure total height the new nodes will need
+// Measure total height the new nodes will need.
+// Each newly created text node uses the same default font, so load it once
+// before the loop rather than awaiting per-iteration.
+const probe = figma.createText()
+await figma.loadFontAsync(probe.fontName)
+probe.remove()
 const newTexts = []
 for (const topic of newTopics) {
   const t = figma.createText()
-  await figma.loadFontAsync(t.fontName)
   t.characters = topic
   newTexts.push(t)
 }

--- a/skills/figma-use-figjam/references/edit-text.md
+++ b/skills/figma-use-figjam/references/edit-text.md
@@ -288,6 +288,11 @@ To search and replace text content across many nodes:
 
 ```javascript
 ;(async () => {
+  // Skip invisible instance interiors — hidden component variants don't need
+  // text replacement, and the flag makes findAllWithCriteria hundreds of
+  // times faster on large boards.
+  figma.skipInvisibleInstanceChildren = true
+
   const searchText = 'Sign Up'
   const replaceText = 'Register'
   const caseSensitive = false

--- a/skills/figma-use-slides/SKILL.md
+++ b/skills/figma-use-slides/SKILL.md
@@ -75,6 +75,37 @@ const slideGrid = figma.currentPage.children.find(c => c.type === "SLIDE_GRID");
 slideGrid.children[0].name = "Intro";
 ```
 
+## Speaker Notes
+
+Speaker notes are the presenter's private companion to each slide. They appear in Presenter View (visible only to the speaker, not the audience) and serve as a script, cue sheet, or talking-points reference during a live presentation.
+
+### When to write speaker notes
+
+- **When asked**: If the user asks for speaker notes, presenter notes, talking points, or a script for a deck, write notes for every slide that has substantive content (skip section dividers or purely decorative slides unless there's something to say).
+- **Presenter-ready decks**: If the user explicitly asks for a deck that is ready to present live, speaker notes are useful. Add them when they help the presenter understand pacing, transitions, or context that is not visible on the slide.
+- **Sparse or visual slides**: If a slide is built around a chart, image, metaphor, or provocative question, notes can help explain what the presenter should say. Use screenshots or `node.screenshot()` for image-heavy, chart-heavy, or visually sparse slides when visual context matters, but don't screenshot every slide by default — images spend context budget.
+- **Don't add notes unprompted**: For normal slide edits, layout work, or updates to existing decks, do not populate speaker notes unless the user asks. Adding notes changes the presentation flow and can surprise the deck owner.
+
+### What good speaker notes look like
+
+Speaker notes are for the *presenter*, not the audience. They should feel like a trusted colleague leaning over and whispering "here's what to say." Good notes:
+
+- **Complement the slide, not repeat it.** If the slide says "Revenue grew 40%", the notes shouldn't say "Revenue grew 40%." They should say *why* it grew, what the audience should take away, or what question this usually prompts.
+- **Are concise and scannable.** A presenter glancing down mid-sentence needs to find their place instantly. Use short bullet points, not dense paragraphs. Each point should be one idea.
+- **Include transitions.** The best notes tell the presenter how to *move* between slides: "After the applause dies down..." or "This builds on the previous point — call back to the 40% figure."
+- **Carry context the slide can't.** Data sources ("Source: Q4 FY25 internal metrics, not yet public"), caveats ("Skip this slide if the CFO is in the room"), timing cues ("This is the halfway point — you should be at ~10 minutes"), and anticipated questions ("They'll ask about margins — see appendix slide 14").
+- **Match the presentation's register.** Notes for an investor pitch are precise and rehearsed. Notes for a team retro are casual and flexible. Notes for a keynote might include stage directions. Match the tone to the context.
+
+### What to avoid in speaker notes
+
+- **Full scripts**: Wall-of-text notes encourage reading verbatim, which makes for a terrible presentation. If the user explicitly asks for a script, write one, but default to bullet points.
+- **Formatting for the audience**: Notes aren't visible to the audience. Don't optimize them for readability by non-presenters.
+- **Redundancy with the slide**: If the slide is self-explanatory ("Thank You" with contact info), notes aren't needed. It's fine to leave a slide's notes empty.
+
+### Formatting
+
+`slide.speakerNotes` accepts a markdown string. Prefer bullet lists as the primary structure; bold is useful for emphasis on key phrases the presenter shouldn't skip. See [slide-properties.md](references/slide-properties.md#supported-formatting) for the full list of supported (lists, bold, italic, strikethrough) and unsupported (headings, code blocks, inline code, links) markdown.
+
 ## Inspecting Slides Files
 
 There is no dedicated read tool for Slides files yet. Use `use_figma` with read-only scripts for inspection, and `get_screenshot` / `await node.screenshot()` for visual context.
@@ -96,14 +127,20 @@ return grid.map((row, rowIdx) =>
     row: rowIdx,
     col: colIdx,
     isSkipped: slide.isSkippedSlide,
+    speakerNotes: slide.speakerNotes,
   }))
 );
 ```
 
 **Get text content from a specific slide:**
 ```js
+// Read-only text inventory — skip invisible instance interiors for speed.
+figma.skipInvisibleInstanceChildren = true;
+
 const slide = figma.getNodeById("TARGET_SLIDE_ID");
-const textNodes = slide.findAll(n => n.type === "TEXT");
+// findAllWithCriteria uses an indexed type lookup — much faster than
+// findAll(n => n.type === 'TEXT') on slides with many shapes/images.
+const textNodes = slide.findAllWithCriteria({ types: ["TEXT"] });
 const fontsToLoad = new Set();
 for (const t of textNodes) {
   if (t.fontName !== figma.mixed) {
@@ -135,5 +172,5 @@ Load only the references your task needs:
 - [slide-lifecycle](references/slide-lifecycle.md) — Create, clone, delete, and reorder slides and slide rows
 - [slide-grid](references/slide-grid.md) — Work with the slide grid layout (`getSlideGrid`, `setSlideGrid`)
 - [slide-content](references/slide-content.md) — Build content within slides (text, shapes, auto-layout — SlideNode extends BaseFrameMixin)
-- [slide-properties](references/slide-properties.md) — Slide-specific properties (`isSkippedSlide`, `focusedSlide`, `focusedNode`, `slideThemeId`, `InteractiveSlideElementNode`)
+- [slide-properties](references/slide-properties.md) — Slide-specific properties (`speakerNotes`, `isSkippedSlide`, `focusedSlide`, `focusedNode`, `slideThemeId`, `InteractiveSlideElementNode`)
 - [slide-design](references/slide-design.md) — Design principles for visually interesting, varied decks (color strategy, typography, layout variety, spatial composition, anti-patterns)

--- a/skills/figma-use-slides/references/slide-gotchas.md
+++ b/skills/figma-use-slides/references/slide-gotchas.md
@@ -6,6 +6,10 @@
 
 - Position after appendChild (critical)
 - Canonical text-edit recipe (font load → await → mutate → return IDs)
+- Sequential awaits — batch independent async calls with `Promise.all`
+- Prefer indexed lookups over `findAll`/`findOne` full-tree scans
+- Scope traversal to the smallest known ancestor (a slide, not the page)
+- Set `figma.skipInvisibleInstanceChildren = true` for read-only traversal
 - SLIDE_GRID and SLIDE_ROW are opaque nodes
 - Validation without get_metadata
 - Building multi-element slides incrementally
@@ -27,6 +31,61 @@ await Promise.all(
 textNode.characters = "Updated"
 return { mutatedNodeIds: [textNode.id] }
 ```
+
+
+## Prefer indexed lookups over `findAll` / `findOne` full-tree scans
+
+Same rule as in design files (see [figma-use → gotchas.md → Prefer indexed lookups](../../figma-use/references/gotchas.md#prefer-indexed-lookups-over-findall--findone-full-tree-scans)). On slide trees, the most common offenders are `slide.findAll(n => n.type === 'TEXT')` (use `slide.findAllWithCriteria({ types: ['TEXT'] })`) and `slide.findAll(n => n.type === 'INTERACTIVE_SLIDE_ELEMENT')` (same fix). If you have a slide or element ID, use `figma.getNodeByIdAsync(id)` — never re-scan the tree.
+
+
+## Scope traversal to the smallest known ancestor
+
+Slides specifically: **search inside the specific slide**, not the whole page. `slide.findAllWithCriteria(...)` walks one slide; `figma.currentPage.findAllWithCriteria(...)` walks every slide in the deck. When you have the target slide's ID (passed by the caller or returned from a prior call), always start the traversal there.
+
+```js
+// AVOID — scans every slide in the deck
+const texts = figma.currentPage.findAllWithCriteria({ types: ['TEXT'] })
+
+// PREFER — one slide only
+const slide = await figma.getNodeByIdAsync(SLIDE_ID)
+const texts = slide.findAllWithCriteria({ types: ['TEXT'] })
+```
+
+See [figma-use → gotchas.md → Scope traversal to the smallest known ancestor](../../figma-use/references/gotchas.md#scope-traversal-to-the-smallest-known-ancestor).
+
+
+## Set `figma.skipInvisibleInstanceChildren = true` for read-only traversal
+
+Same rule as in design files (see [figma-use → gotchas.md → Set figma.skipInvisibleInstanceChildren](../../figma-use/references/gotchas.md#set-figmaskipinvisibleinstancechildren--true-for-read-only-traversal)). One line at the top of any read-only slide-inspection script. Decks tend to be component-heavy (icons, logo lockups, repeating frames), so this flag is especially impactful.
+
+```js
+figma.skipInvisibleInstanceChildren = true
+const slide = await figma.getNodeByIdAsync(SLIDE_ID)
+const texts = slide.findAllWithCriteria({ types: ['TEXT'] })
+```
+
+Leave the flag off if you specifically need to read invisible content inside an instance (e.g., inspecting all variants of a deck-template instance).
+
+
+## Sequential awaits — batch independent async calls with `Promise.all`
+
+Same rule as in design files (see [figma-use → gotchas.md → Sequential awaits](../../figma-use/references/gotchas.md#sequential-awaits--batch-independent-async-calls-with-promiseall)). When building decks, the typical offenders are `loadFontAsync` for theme/brand fonts, `getNodeByIdAsync` for cached slide IDs, and `import*ByKeyAsync` for library variables and styles — all independent per call and all batchable.
+
+```js
+// WRONG — sequential round-trips per slide
+for (const id of slideIds) {
+  const slide = await figma.getNodeByIdAsync(id)
+  // ... mutate
+}
+
+// CORRECT — fetch all slides in one batch, then mutate sequentially
+const slides = await Promise.all(slideIds.map(id => figma.getNodeByIdAsync(id)))
+for (const slide of slides) {
+  // ... mutate
+}
+```
+
+`setCurrentPageAsync` is the exception — page-context switches must stay sequential.
 
 
 ## Position after appendChild (critical)

--- a/skills/figma-use-slides/references/slide-properties.md
+++ b/skills/figma-use-slides/references/slide-properties.md
@@ -44,13 +44,57 @@ if (focused) {
 }
 ```
 
+## speakerNotes
+
+Read and set the presenter/speaker notes for a slide. The value is a **markdown string**.
+
+```js
+const slide = figma.getNodeById("SLIDE_ID");
+
+// Read speaker notes
+const notes = slide.speakerNotes;
+// Returns "" if no notes are set
+
+// Set speaker notes (plain text)
+slide.speakerNotes = "Remember to mention the Q4 goals.";
+
+// Set speaker notes with list formatting
+slide.speakerNotes = "Key points:\n- Revenue grew 20%\n- User base doubled\n- NPS at all-time high";
+
+// Set speaker notes with numbered list
+slide.speakerNotes = "Agenda:\n1. Introduction\n2. Demo\n3. Q&A";
+
+// Clear speaker notes
+slide.speakerNotes = "";
+```
+
+### Supported formatting
+
+The speaker notes editor in Figma Slides supports a subset of markdown formatting:
+
+- **Unordered lists**: `- item` or `* item`
+- **Ordered lists**: `1. item`, `2. item`
+- **Bold**: `**text**`
+- **Italic**: `*text*`
+- **Bold + italic**: `***text***`
+- **Strikethrough**: `~~text~~`
+
+The following markdown is **not supported** and will be stored as raw text (the markdown syntax characters will appear literally in the notes):
+- Headings (`# text`, `## text`)
+- Code blocks (`` `code` `` or ` ``` `)
+- Links (`[text](url)`)
+- Underline
+
 ## InteractiveSlideElementNode
 
 Interactive elements embedded in slides (polls, embeds, etc.). These are read-only — you cannot create them via the Plugin API, but you can detect and inspect them.
 
 ```js
+// Read-only inspection — skip invisible instance interiors for speed.
+figma.skipInvisibleInstanceChildren = true;
+
 const slide = figma.getNodeById("SLIDE_ID");
-const interactive = slide.findAll(n => n.type === "INTERACTIVE_SLIDE_ELEMENT");
+const interactive = slide.findAllWithCriteria({ types: ["INTERACTIVE_SLIDE_ELEMENT"] });
 return interactive.map(n => ({
   id: n.id,
   type: n.interactiveSlideElementType,

--- a/skills/figma-use/SKILL.md
+++ b/skills/figma-use/SKILL.md
@@ -14,6 +14,8 @@ Use the `use_figma` tool to execute JavaScript in Figma files via the Plugin API
 
 **If the task involves building or updating a full page, screen, or multi-section layout in Figma from code**, also load [figma-generate-design](../figma-generate-design/SKILL.md). It provides the workflow for discovering design system components via `search_design_system`, importing them, and assembling screens incrementally. Both skills work together: this one for the API rules, that one for the screen-building workflow.
 
+**If the task involves creating or building a component in Figma** (even a single component), also load [figma-generate-library](../figma-generate-library/SKILL.md). It provides the component creation workflow — variable foundations, variant sets, design token bindings — that `figma-use` alone doesn't cover.
+
 Before anything, load [plugin-api-standalone.index.md](references/plugin-api-standalone.index.md) to understand what is possible. When you are asked to write plugin API code, use this context to grep [plugin-api-standalone.d.ts](references/plugin-api-standalone.d.ts) for relevant types, methods, and properties. This is the definitive source of truth for the API surface. It is a large typings file, so do not load it all at once, grep for relevant sections as needed.
 
 IMPORTANT: Whenever you work with design systems, start with [working-with-design-systems/wwds.md](references/working-with-design-systems/wwds.md) to understand the key concepts, processes, and guidelines for working with design systems in Figma. Then load the more specific references for components, variables, text styles, and effect styles as needed.
@@ -55,13 +57,28 @@ Use `await figma.setCurrentPageAsync(page)` to switch pages and load their conte
 const targetPage = figma.root.children.find((p) => p.name === "My Page");
 await figma.setCurrentPageAsync(targetPage);
 // targetPage.children is now populated
+```
 
-// Iterate over all pages
+### Call `setCurrentPageAsync` at most once per `use_figma` invocation — fan multi-page work out in parallel
+
+**One script must switch pages at most once.** Never loop over `figma.root.children` and switch pages inside the loop.
+
+If the work spans multiple pages, **split it into N `use_figma` calls (one per target page) and emit them in parallel** — a single assistant message containing N `use_figma` tool-use blocks. The harness runs them concurrently; each script sets `currentPage` exactly once.
+
+> **Explicit instruction:** when fanning out, you MUST issue the N tool calls in **one message**. Do not send them across multiple turns. Do not await one before issuing the next. Sequential per-page calls are slower than the in-loop pattern this rule replaces and waste the entire benefit of splitting.
+
+```js
+// AVOID — switches pages N times in one script, reloads the file each time
 for (const page of figma.root.children) {
   await figma.setCurrentPageAsync(page);
-  // page.children is now loaded — read or modify them here
+  // ... touch this page ...
 }
+
+// PREFER — read-only discovery call to get page IDs, then in the NEXT message
+// emit N parallel use_figma tool calls (one per page), each setting currentPage once.
 ```
+
+Default to parallel fan-out for any multi-page work — reads and writes alike. See [gotchas.md → Set current page once per `use_figma` call](references/gotchas.md#set-current-page-once-per-use_figma-call--split-multi-page-work-into-parallel-calls) for the full rationale.
 
 ### Across script runs
 
@@ -364,17 +381,26 @@ return pages.join('\n');
 ```
 
 **List existing components across all pages:**
+
+`search_design_system` is an option for published components. For on-canvas components, use the two-step fan-out — **don't loop pages inside one script.**
+
+Step 1: one read-only `use_figma` to get page IDs:
 ```js
-const results = [];
-for (const page of figma.root.children) {
-  await figma.setCurrentPageAsync(page);
-  page.findAll(n => {
-    if (n.type === 'COMPONENT' || n.type === 'COMPONENT_SET')
-      results.push(`[${page.name}] ${n.name} (${n.type}) id=${n.id}`);
-    return false;
-  });
-}
-return results.join('\n');
+return figma.root.children.map(p => ({ id: p.id, name: p.name }));
+```
+
+Step 2: in the **next assistant turn, emit one `use_figma` per page in parallel** (a single message containing N tool-use blocks). Each runs:
+```js
+// Read-only inspection — skip invisible instance interiors for the
+// hundreds-of-times-faster findAllWithCriteria.
+figma.skipInvisibleInstanceChildren = true;
+
+const page = await figma.getNodeByIdAsync(PAGE_ID);
+await figma.setCurrentPageAsync(page);
+// findAllWithCriteria uses an indexed type lookup — hundreds of times faster
+// than the findAll(n => n.type === '…') side-effect-in-predicate antipattern.
+const matches = page.findAllWithCriteria({ types: ['COMPONENT', 'COMPONENT_SET'] });
+return matches.map(n => ({ page: page.name, name: n.name, type: n.type, id: n.id }));
 ```
 
 **List existing variable collections and their conventions:**

--- a/skills/figma-use/references/api-reference.md
+++ b/skills/figma-use/references/api-reference.md
@@ -336,4 +336,4 @@ node.parent                    // Parent node
 | `figma.loadAllPagesAsync()` | Not implemented |
 | `figma.variables.extendLibraryCollectionByKeyAsync()` | Not implemented |
 | `figma.teamLibrary.*` | Not implemented (requires the team-library backend) |
-| `figma.getLocalComponents*()` | **Does not exist** — unlike styles, there is no `getLocalComponents()` or `getLocalComponentSetsAsync()` (or any `getLocalComponent*` variant). Use `findAll(n => n.type === 'COMPONENT')` / `findAll(n => n.type === 'COMPONENT_SET')` to locate components in the current file. |
+| `figma.getLocalComponents*()` | **Does not exist** — unlike styles, there is no `getLocalComponents()` or `getLocalComponentSetsAsync()` (or any `getLocalComponent*` variant). Use `page.findAllWithCriteria({ types: ['COMPONENT', 'COMPONENT_SET'] })` to locate components in the current file (avoid the slower `findAll(n => n.type === '…')` predicate scan). |

--- a/skills/figma-use/references/common-patterns.md
+++ b/skills/figma-use/references/common-patterns.md
@@ -224,15 +224,19 @@ return {
 `importComponentByKeyAsync` and `importComponentSetByKeyAsync` import components from **team libraries** (not the same file you're working in). For components in the current file, use `figma.getNodeByIdAsync()` or `findOne()`/`findAll()` to locate them directly.
 
 ```js
-// Import a single published component by key
-const comp = await figma.importComponentByKeyAsync("COMPONENT_KEY")
+// Batch independent imports with Promise.all — these are independent IPC
+// calls; awaiting them one after another doubles the round-trip latency.
+const [comp, compSet] = await Promise.all([
+  figma.importComponentByKeyAsync("COMPONENT_KEY"),
+  figma.importComponentSetByKeyAsync("COMPONENT_SET_KEY"),
+])
+
 const instance = comp.createInstance()
 instance.x = 40
 instance.y = 40
 figma.currentPage.appendChild(instance)
 
-// Import a published component set by key and select a variant
-const compSet = await figma.importComponentSetByKeyAsync("COMPONENT_SET_KEY")
+// Select a variant from the imported component set
 const variant =
   compSet.children.find((c) =>
     c.type === "COMPONENT" && c.name.includes("size=md")
@@ -429,7 +433,10 @@ return { csId: cs.id, count: components.length };
 
 ```js
 const page = figma.currentPage
-const nodes = page.findAll(n => n.type === 'FRAME')
+// findAllWithCriteria is hundreds of times faster than findAll for a pure
+// type filter — the engine uses an internal type index instead of running
+// a JS predicate on every node.
+const nodes = page.findAllWithCriteria({ types: ['FRAME'] })
 const data = nodes.map(n => ({
   id: n.id,
   name: n.name,

--- a/skills/figma-use/references/component-patterns.md
+++ b/skills/figma-use/references/component-patterns.md
@@ -201,7 +201,10 @@ const btn = figma.createFrame();
 btn.layoutMode = "HORIZONTAL";
 btn.cornerRadius = 8;
 
-const contentSlot = instance.findOne(n => n.type === "SLOT" && n.name === "Content");
+// Use the type-indexed criteria for the type filter, then narrow by name.
+const contentSlot = instance
+  .findAllWithCriteria({ types: ["SLOT"] })
+  .find(n => n.name === "Content");
 contentSlot.appendChild(btn);
 
 // If a post-append edit throws "Parent not found", re-find via the slot:
@@ -244,18 +247,31 @@ This works for icons, avatars, badges, or any swappable nested element.
 
 ### List all existing components across all pages
 
+`search_design_system` (MCP tool) is an option for published components. For on-canvas components, **don't loop pages inside one script** — even for read-only discovery.
+
+**Prefer the two-step fan-out:**
+
 ```javascript
-const results = [];
-for (const page of figma.root.children) {
-  await figma.setCurrentPageAsync(page);
-  page.findAll(n => {
-    if (n.type === 'COMPONENT') results.push(`[${page.name}] ${n.name} (COMPONENT) id=${n.id}`);
-    if (n.type === 'COMPONENT_SET') results.push(`[${page.name}] ${n.name} (COMPONENT_SET) id=${n.id}`);
-    return false;
-  });
-}
-return results.join('\n');
+// Step 1 — one cheap use_figma call, no page switch. Returns the page IDs to fan out over.
+return figma.root.children.map(p => ({ id: p.id, name: p.name }));
 ```
+
+Then in the **next assistant turn, emit one `use_figma` per page in parallel** (a single message with N tool-use blocks). Each script runs:
+
+```javascript
+// Read-only discovery — skip invisible instance interiors for speed.
+figma.skipInvisibleInstanceChildren = true;
+
+// Step 2 — one call per page, currentPage set exactly once.
+// The agent MUST issue N of these in parallel in one message — do not loop pages inside the script.
+const page = await figma.getNodeByIdAsync(PAGE_ID); // PAGE_ID supplied by caller
+await figma.setCurrentPageAsync(page);
+// Indexed type lookup — much faster than findAll with a side-effect predicate.
+const matches = page.findAllWithCriteria({ types: ['COMPONENT', 'COMPONENT_SET'] });
+return matches.map(n => ({ pageName: page.name, name: n.name, type: n.type, id: n.id }));
+```
+
+See [gotchas.md → Set current page once per `use_figma` call](gotchas.md#set-current-page-once-per-use_figma-call--split-multi-page-work-into-parallel-calls) for the full rule.
 
 ### Inspect an existing component set's variant naming pattern
 
@@ -268,18 +284,25 @@ return { variantNames, propDefs };
 
 ### Find existing components in the file
 
+`search_design_system` is an option for published components. For on-canvas components, use the two-step fan-out from the section above — **don't loop pages inside one script.**
+
+**Step 1** — one cheap `use_figma` call returns page IDs:
+
 ```javascript
-const components = [];
-for (const page of figma.root.children) {
-  await figma.setCurrentPageAsync(page);
-  page.findAll(n => {
-    if (n.type === 'COMPONENT') {
-      components.push({ name: n.name, id: n.id, page: page.name, w: n.width, h: n.height });
-    }
-    return false;
-  });
-}
-return components;
+return figma.root.children.map(p => ({ id: p.id, name: p.name }));
+```
+
+**Step 2** — the agent MUST emit one `use_figma` per page in parallel (a single message with N tool-use blocks). Each script:
+
+```javascript
+// Read-only discovery — skip invisible instance interiors for speed.
+figma.skipInvisibleInstanceChildren = true;
+
+const page = await figma.getNodeByIdAsync(PAGE_ID);
+await figma.setCurrentPageAsync(page);
+// Indexed type lookup — much faster than findAll with a side-effect predicate.
+const components = page.findAllWithCriteria({ types: ['COMPONENT'] });
+return components.map(n => ({ name: n.name, id: n.id, page: page.name, w: n.width, h: n.height }));
 ```
 
 ## Importing Components by Key (Team Libraries)
@@ -287,12 +310,15 @@ return components;
 `importComponentByKeyAsync` and `importComponentSetByKeyAsync` import components from **team libraries** (not the same file you're working in). For components in the current file, use `figma.getNodeByIdAsync()` or `findOne()`/`findAll()` to locate them directly.
 
 ```javascript
-// Import a component from a team library
-const comp = await figma.importComponentByKeyAsync("COMPONENT_KEY");
+// Batch independent imports with Promise.all — sequential awaits multiply
+// IPC latency by the number of imports for no benefit.
+const [comp, set] = await Promise.all([
+  figma.importComponentByKeyAsync("COMPONENT_KEY"),
+  figma.importComponentSetByKeyAsync("COMPONENT_SET_KEY"),
+]);
+
 const instance = comp.createInstance();
 
-// Import a component set from a team library and pick a variant
-const set = await figma.importComponentSetByKeyAsync("COMPONENT_SET_KEY");
 const variant = set.children.find(c =>
   c.type === "COMPONENT" && c.name.includes("size=md")
 ) || set.defaultVariant;
@@ -346,7 +372,7 @@ return propDefs;
 Also check nested instances — a parent component may not expose text properties directly, but its nested child instances might:
 
 ```javascript
-const nestedInstances = instance.findAll(n => n.type === "INSTANCE");
+const nestedInstances = instance.findAllWithCriteria({ types: ["INSTANCE"] });
 const nestedProps = nestedInstances.map(ni => ({
   name: ni.name,
   id: ni.id,
@@ -369,7 +395,10 @@ for (const [key, def] of Object.entries(propDefs)) {
 For nested instances that expose their own TEXT properties, call `setProperties()` on the nested instance:
 
 ```javascript
-const nestedHeading = instance.findOne(n => n.type === "INSTANCE" && n.name === "Text Heading");
+// Use the type-indexed criteria for the type filter, then narrow by name.
+const nestedHeading = instance
+  .findAllWithCriteria({ types: ["INSTANCE"] })
+  .find(n => n.name === "Text Heading");
 if (nestedHeading) {
   nestedHeading.setProperties({ "Text#2104:5": "Actual heading text" });
 }
@@ -378,9 +407,15 @@ if (nestedHeading) {
 **Step 3: Only fall back to direct node.characters for unmanaged text.** If text is NOT controlled by any component property, find text nodes directly. **Always load the node's actual font first** — instance text nodes inherit fonts from the source component, so don't assume Inter Regular:
 
 ```javascript
-const textNodes = instance.findAll(n => n.type === "TEXT");
+const textNodes = instance.findAllWithCriteria({ types: ["TEXT"] });
+// Dedupe fonts and load them in parallel before mutating text. Awaiting
+// loadFontAsync per node in the loop serializes one IPC round-trip per
+// text node and reloads the same font repeatedly.
+const uniqueFonts = [...new Map(
+  textNodes.map(t => [JSON.stringify(t.fontName), t.fontName])
+).values()];
+await Promise.all(uniqueFonts.map(f => figma.loadFontAsync(f)));
 for (const t of textNodes) {
-  await figma.loadFontAsync(t.fontName);
   t.characters = "Updated text";
 }
 ```

--- a/skills/figma-use/references/gotchas.md
+++ b/skills/figma-use/references/gotchas.md
@@ -6,10 +6,14 @@
 
 - Component properties and variant creation pitfalls
 - Paint, color, and variable binding pitfalls
-- Page context and plugin lifecycle pitfalls
+- Page context and plugin lifecycle pitfalls (set current page once per `use_figma` call; split multi-page work across calls)
 - Auto Layout and sizing order pitfalls (including HUG/FILL interactions)
 - Variant layout and geometry pitfalls
 - Canonical text-edit recipe + font loading and text/typography pitfalls
+- Sequential awaits — batch independent async calls with `Promise.all` (including `import*ByKeyAsync` families)
+- Prefer indexed lookups (`getNodeByIdAsync`, `findAllWithCriteria`, `node.query`) over `findAll`/`findOne` full-tree scans
+- Scope traversal to the smallest known ancestor (never `figma.root.findAll`; prefer `someFrame.findAllWithCriteria` over `figma.currentPage.findAllWithCriteria`)
+- Set `figma.skipInvisibleInstanceChildren = true` for read-only traversal that doesn't need the interior of component instances
 - Variable scopes and mode pitfalls
 - Node cleanup and empty-fill pitfalls
 - Type-specific method calls without node type guards
@@ -184,6 +188,46 @@ await figma.setCurrentPageAsync(targetPage)
 const page = figma.currentPage  // works
 ```
 
+## Set current page once per `use_figma` call — split multi-page work into parallel calls
+
+**A `use_figma` script must call `setCurrentPageAsync` at most once.** Never loop over `figma.root.children` and switch pages inside one script.
+
+**The rule is the same for reads and writes:** if work spans multiple pages, split it into **multiple `use_figma` tool calls, one per target page, and YOU MUST issue them in parallel**.
+
+> **Explicit instruction to the agent:** emit all N `use_figma` calls in a **single assistant message**, as N parallel tool-use blocks. Do not send them in separate turns. Do not await one before issuing the next. Each call sets `currentPage` exactly once; the harness runs them concurrently. Sequential per-page calls defeat the entire point of splitting and are slower than the in-loop pattern this rule replaces.
+
+```js
+// WRONG — one script switches pages on every iteration; reloads the file N times sequentially
+const componentsByPage = {}
+for (const page of figma.root.children) {
+  await figma.setCurrentPageAsync(page)
+  componentsByPage[page.name] = page.findAllWithCriteria({ types: ['COMPONENT'] }).map(n => n.id)
+}
+return componentsByPage
+```
+
+Instead, do it in two steps and parallelize step 2:
+
+```js
+// CORRECT — step 1: cheap, no page switch. Return the page IDs you'll fan out over.
+return figma.root.children.map(p => ({ id: p.id, name: p.name }))
+```
+
+Then in the **next assistant turn**, emit **N parallel `use_figma` tool-use blocks in one message** — one per page. Each script runs this:
+
+```js
+// CORRECT — step 2: one call per page, currentPage set exactly once.
+// The assistant issues N of these in parallel — do NOT loop pages inside the script.
+const page = await figma.getNodeByIdAsync(PAGE_ID)  // PAGE_ID supplied by caller
+await figma.setCurrentPageAsync(page)
+// ... read or mutate this page ...
+return { pageId: page.id, components: page.findAllWithCriteria({ types: ['COMPONENT'] }).map(n => n.id) }
+```
+
+This applies to discovery, mutation, component-set creation, and audits — reads and writes alike. **The only acceptable reason to switch pages multiple times in one script is when splitting would break a transactional/atomicity guarantee** (i.e., the operation must succeed across all pages or none, and a partial failure between calls would corrupt state). "It's read-only" and "I want a consistent snapshot" are *not* exceptions — fan out in parallel.
+
+The same rule generalizes to *any* traversal: scope it to the smallest known ancestor — see [Scope traversal to the smallest known ancestor](#scope-traversal-to-the-smallest-known-ancestor).
+
 ## `get_metadata` operates on one subtree — discover pages explicitly
 
 A Figma file can have multiple pages (canvas nodes). `get_metadata` only returns the subtree of whichever node you pass it. To get a usable index of every page:
@@ -308,6 +352,192 @@ return { mutatedNodeIds: [textNode.id] }
 ```
 
 Font loading is also required for **any** operation on nodes that contain unloaded fonts — `appendChild`, `insertChild`, `setBoundVariable`, `setExplicitVariableModeForCollection`, `setValueForMode`, and even `findAll` callbacks that touch text properties. If the document has existing text nodes you'll traverse, preload their fonts at the start of the script.
+
+## Sequential awaits — batch independent async calls with `Promise.all`
+
+Awaiting an independent async call inside a `for`/`for…of` loop — or sequentially in a straight-line block — serializes one IPC round-trip per call. Each call to `getNodeByIdAsync`, `getVariableByIdAsync`, `loadFontAsync`, `setTextStyleIdAsync`, **`importComponentByKeyAsync`, `importComponentSetByKeyAsync`, `importStyleByKeyAsync`, `importVariableByKeyAsync`**, etc. is independent — batch them with `Promise.all`. The only awaits that *must* stay sequential are `setCurrentPageAsync` (changes global page context) and explicit per-iteration dependencies.
+
+Sequential `import*ByKeyAsync` calls at the top of a `use_figma` script are a particularly common offender — design-system scripts often import a component set plus several variables plus an effect style in a row. **Always batch the imports:**
+
+```js
+// WRONG — four sequential round-trips at the start of every section build
+const buttonSet   = await figma.importComponentSetByKeyAsync("BUTTON_SET_KEY")
+const bgVar       = await figma.variables.importVariableByKeyAsync("BG_COLOR_VAR_KEY")
+const spacingVar  = await figma.variables.importVariableByKeyAsync("SPACING_VAR_KEY")
+const shadowStyle = await figma.importStyleByKeyAsync("SHADOW_STYLE_KEY")
+
+// CORRECT — one round-trip
+const [buttonSet, bgVar, spacingVar, shadowStyle] = await Promise.all([
+  figma.importComponentSetByKeyAsync("BUTTON_SET_KEY"),
+  figma.variables.importVariableByKeyAsync("BG_COLOR_VAR_KEY"),
+  figma.variables.importVariableByKeyAsync("SPACING_VAR_KEY"),
+  figma.importStyleByKeyAsync("SHADOW_STYLE_KEY"),
+])
+```
+
+```js
+// WRONG — N sequential round-trips, scales linearly with list length
+const vars = {}
+for (const id of collection.variableIds) {
+  vars[id] = await figma.variables.getVariableByIdAsync(id)
+}
+
+// CORRECT — one round-trip
+const fetched = await Promise.all(
+  collection.variableIds.map(id => figma.variables.getVariableByIdAsync(id))
+)
+const vars = {}
+collection.variableIds.forEach((id, i) => { vars[id] = fetched[i] })
+```
+
+When the loop only needs the *same* font for every iteration, load it once before the loop instead of inside it. (For freshly-created `TextNode`s this is the platform default — typically Inter Regular in design files; for FigJam sticky/shape sublayers it's Inter Medium. Either way, read `node.fontName` rather than hardcoding.)
+
+```js
+// WRONG — loads the same default font on every iteration
+for (const label of labels) {
+  const t = figma.createText()
+  await figma.loadFontAsync(t.fontName)
+  t.characters = label
+}
+
+// CORRECT — load once, then mutate synchronously
+const probe = figma.createText()
+await figma.loadFontAsync(probe.fontName)
+probe.remove()
+for (const label of labels) {
+  const t = figma.createText()
+  t.characters = label
+}
+```
+
+If you do need different fonts per node, dedupe and `Promise.all` them up-front:
+
+```js
+const uniqueFonts = [...new Map(
+  textNodes.map(t => [JSON.stringify(t.fontName), t.fontName])
+).values()]
+await Promise.all(uniqueFonts.map(f => figma.loadFontAsync(f)))
+```
+
+## Prefer indexed lookups over `findAll` / `findOne` full-tree scans
+
+**Rule: use `findAllWithCriteria({ types: [...] })` for type-based searches. Reserve `findOne` / `findAll(predicate)` for cases the criteria API can't express** — name patterns, regex, capability checks (`'fills' in n`), or any predicate that touches properties the engine doesn't index.
+
+`findAll` and `findOne` walk the entire subtree node-by-node and run a JS predicate on each one. For anything the Figma engine already indexes (type, pluginData, sharedPluginData), there is a much faster API. Use this table:
+
+| You want… | DON'T | DO |
+|---|---|---|
+| One specific node, you have its ID | `page.findOne(n => n.id === id)` | `await figma.getNodeByIdAsync(id)` |
+| All nodes of a given type | `page.findAll(n => n.type === 'TEXT')` | `page.findAllWithCriteria({ types: ['TEXT'] })` |
+| Type + a few cheap attributes (`name`, `visible`, etc.) | `page.findAll(n => n.type === 'TEXT' && n.name === 'Title')` | `page.query('TEXT[name=Title]')` (see [SKILL.md → node.query](../SKILL.md#nodequeryselector--css-like-node-search)) |
+| Nodes with plugin data | `page.findAll(n => n.getPluginData('key'))` | `page.findAllWithCriteria({ pluginData: { keys: ['key'] } })` |
+| Nodes with shared plugin data | `page.findAll(n => n.getSharedPluginData('ns', 'key'))` | `page.findAllWithCriteria({ sharedPluginData: { namespace: 'ns', keys: ['key'] } })` |
+
+**`types` and `pluginData.keys` are arrays — pass multiple values in a single call instead of issuing N separate ones.** A union over `types` is OR'd; multiple `pluginData.keys` match nodes that carry *any* of the given keys.
+
+```js
+// Multiple types in one call — returns COMPONENT ∪ COMPONENT_SET in one indexed pass
+page.findAllWithCriteria({ types: ['COMPONENT', 'COMPONENT_SET'] })
+
+// Multiple pluginData keys in one call — matches nodes that have any of them
+page.findAllWithCriteria({ pluginData: { keys: ['dsb_key', 'dsb_run_id'] } })
+
+// Multiple sharedPluginData keys (under the same namespace)
+page.findAllWithCriteria({ sharedPluginData: { namespace: 'dsb', keys: ['key', 'run_id'] } })
+```
+
+Two more rules that apply to any traversal — see also the dedicated [Scope traversal to the smallest known ancestor](#scope-traversal-to-the-smallest-known-ancestor) gotcha below:
+
+1. **Narrow the scope.** `frame.findAll(...)` is much cheaper than `figma.currentPage.findAll(...)`. Hold onto the smallest known subtree.
+2. **Skip invisible instance children when relevant** — see the dedicated [Set `figma.skipInvisibleInstanceChildren = true` for read-only traversal](#set-figmaskipinvisibleinstancechildren--true-for-read-only-traversal) gotcha. One line at the top of the script, up to hundreds of times faster on large files.
+
+```js
+// WRONG — full-tree scan for a single node you already have an ID for
+const button = figma.currentPage.findOne(n => n.id === BUTTON_ID)
+
+// CORRECT — indexed lookup
+const button = await figma.getNodeByIdAsync(BUTTON_ID)
+
+// WRONG — type filter via predicate (walks every node)
+const textNodes = figma.currentPage.findAll(n => n.type === 'TEXT')
+
+// CORRECT — type filter via criteria (indexed, hundreds of times faster on large docs)
+const textNodes = figma.currentPage.findAllWithCriteria({ types: ['TEXT'] })
+
+// WRONG — full traversal when you only need a couple of types
+frame.findAll(() => true).forEach(node => { /* only touches TEXT and INSTANCE */ })
+
+// CORRECT — restrict to the types you actually care about
+const candidates = frame.findAllWithCriteria({ types: ['TEXT', 'INSTANCE'] })
+for (const node of candidates) { /* ... */ }
+```
+
+**Caveat — don't enumerate every scene type just to use criteria.** If you'd need to list ~10+ types (e.g., "any node that can carry `boundVariables` or `effectStyleId`"), the type list is no longer narrowing — it's enumerating. `findAll(() => true)` is shorter, equivalently fast on real screen-sized subtrees, and saves a lot of script tokens. Reserve `findAllWithCriteria` for genuine narrowing (one to a handful of types).
+
+**When the predicate combines type + name (or another non-indexed attribute), use criteria for the type and a `.filter`/`.find` for the rest** — the criteria stage already narrows the candidate set to the matching type using the index:
+
+```js
+// WRONG — predicate walks every node
+const slot = instance.findOne(n => n.type === 'SLOT' && n.name === 'Content')
+
+// CORRECT — type-indexed criteria + name filter
+const slot = instance
+  .findAllWithCriteria({ types: ['SLOT'] })
+  .find(n => n.name === 'Content')
+```
+
+Name-only lookups (`findOne(n => n.name === 'X')`) cannot use criteria — they remain the right tool when you only have a name. But if you can capture the node's ID once and re-fetch with `getNodeByIdAsync` on subsequent calls, prefer that over searching by name again.
+
+## Scope traversal to the smallest known ancestor
+
+Every `findAll` / `findOne` / `findAllWithCriteria` walks the entire subtree of the receiver. Picking the right receiver is the single biggest performance lever you have — bigger than the type index, bigger than `skipInvisibleInstanceChildren`. Cheapest to most expensive:
+
+| Receiver | Walks… |
+|---|---|
+| `someFrame.findAllWithCriteria(...)` | one frame's subtree |
+| `figma.currentPage.findAllWithCriteria(...)` | one page (every loaded node on it) |
+| `figma.root.findAllWithCriteria(...)` | **every loaded page in the document** — only safe on tiny files |
+
+**Rule: scope traversal to the smallest known ancestor.** If you have a specific frame's ID, search inside that frame. If you have a section, search inside that section. Drop back to `figma.currentPage` only when the work is genuinely page-wide.
+
+```js
+// WRONG — walks every loaded page in the document
+const all = figma.root.findAllWithCriteria({ types: ['INSTANCE'] })
+
+// BETTER — one page only
+const onPage = figma.currentPage.findAllWithCriteria({ types: ['INSTANCE'] })
+
+// BEST — when you have the parent frame's ID, search just that subtree
+const frame = await figma.getNodeByIdAsync(FRAME_ID)
+const inFrame = frame.findAllWithCriteria({ types: ['INSTANCE'] })
+```
+
+**Never use `figma.root.findAll(...)` in a `use_figma` script.** It walks every page that has been loaded into memory and forces every other page to load if not already in memory — the worst-case traversal. There is no legitimate use of it in this codebase.
+
+**Never loop `figma.root.children` calling `setCurrentPageAsync(page)` and then `page.findAll(...)`** — that's the same antipattern in slow motion: one whole-page scan per page, plus the cost of switching pages. If work spans multiple pages, **fan out** instead: emit one `use_figma` per page in parallel (see [Set current page once per `use_figma` call](#set-current-page-once-per-use_figma-call--split-multi-page-work-into-parallel-calls)).
+
+When you don't have a frame ID handy, capture one from a parent call and pass it to subsequent calls — `getNodeByIdAsync(id).findAllWithCriteria(...)` beats `figma.currentPage.findAllWithCriteria(...)` every time the target subtree is smaller than the page.
+
+## Set `figma.skipInvisibleInstanceChildren = true` for read-only traversal
+
+**Rule: set `figma.skipInvisibleInstanceChildren = true` at the top of any read-only script that doesn't need the interior of component instances.** It prunes every invisible node inside instances (and that node's descendants, even visible ones) from traversal and from `getNodeByIdAsync`. Per the [Figma docs](https://developers.figma.com/docs/plugins/api/properties/figma-skipinvisibleinstancechildren/), this can make `findAllWithCriteria` up to **hundreds of times faster** on large documents.
+
+```js
+// Top of script — set once, before any traversal.
+figma.skipInvisibleInstanceChildren = true
+
+// Now findAll / findOne / findAllWithCriteria / getNodeByIdAsync all skip
+// invisible content inside instances (and their descendants).
+const components = figma.currentPage.findAllWithCriteria({ types: ['COMPONENT'] })
+return components.map(c => c.id)
+```
+
+**Key points:**
+- **Default is not consistent across surfaces.** `true` in Dev Mode; `false` in Figma and FigJam. Set it explicitly — don't rely on the default.
+- **Only prunes inside `INSTANCE` subtrees.** Invisible nodes outside instances are still traversed normally. COMPONENT (master) subtrees are not affected.
+- **Stale references throw.** Once the flag is `true`, any node handle you previously captured for a pruned (invisible-in-instance) node throws when you read a property on it. Don't toggle the flag mid-script if you've already cached such handles.
+- **Don't set it when you need invisible variants.** Scripts that read or mutate hidden states of a component instance (e.g. inspecting the `disabled` variant's text, restyling all variants of a component set) must leave the flag at `false`.
+- **Safe for almost all read-only discovery and most mutations:** find/replace, style auditing, plugin-data inventory, variable usage scans, idempotency lookups, batch property changes via `setProperties()` on top-level instances. Hidden variants aren't displayed anyway, so skipping them rarely matters.
 
 ## Font style names are file-dependent — use `listAvailableFontsAsync` to discover them
 

--- a/skills/figma-use/references/plugin-api-patterns.md
+++ b/skills/figma-use/references/plugin-api-patterns.md
@@ -391,12 +391,14 @@ instance.y = 100;
 These methods import components from **team libraries** (not the same file). For components in the current file, use `figma.getNodeByIdAsync()` or `findOne()`/`findAll()`.
 
 ```javascript
-// Import a published component from a team library by its key
-const comp = await figma.importComponentByKeyAsync(componentKey)
-const instance = comp.createInstance()
+// Batch independent imports with Promise.all — sequential awaits multiply
+// IPC latency by the number of imports for no benefit.
+const [comp, set] = await Promise.all([
+  figma.importComponentByKeyAsync(componentKey),
+  figma.importComponentSetByKeyAsync(componentSetKey),
+])
 
-// Import a published component set from a team library by its key
-const set = await figma.importComponentSetByKeyAsync(componentSetKey)
+const instance = comp.createInstance()
 const variant = set.defaultVariant
 const variantInstance = variant.createInstance()
 ```
@@ -490,13 +492,17 @@ clone.name = "Copy of " + originalNode.name;
 ## Finding Nodes
 
 ```javascript
-// Find by name on current page
+// If you already have the node's ID, NEVER scan — use the indexed lookup.
+const known = await figma.getNodeByIdAsync("123:456");
+
+// Find by name on current page (no ID available)
 const node = figma.currentPage.findOne(n => n.name === "My Frame");
 
-// Find all by type
-const allTexts = figma.currentPage.findAll(n => n.type === "TEXT");
+// Find all by type — use findAllWithCriteria, hundreds of times faster than
+// findAll(n => n.type === '…') because the engine uses an internal type index.
+const allTexts = figma.currentPage.findAllWithCriteria({ types: ["TEXT"] });
 
-// Find all by name pattern
+// Find all by name pattern (predicate is fine — criteria doesn't index name)
 const allButtons = figma.currentPage.findAll(n => n.name.startsWith("Button/"));
 ```
 

--- a/skills/figma-use/references/plugin-api-standalone.d.ts
+++ b/skills/figma-use/references/plugin-api-standalone.d.ts
@@ -10838,6 +10838,12 @@ interface SlideNode extends BaseFrameMixin {
    * Read and set whether or not the slide is skipped in the presentation.
    */
   isSkippedSlide: boolean
+  /**
+   * Read and set the speaker notes for this slide as a markdown string. See
+   * the figma-use-slides skill's slide-properties reference for the full
+   * list of supported and unsupported markdown formatting.
+   */
+  speakerNotes: string
 }
 /**
  * @see https://developers.figma.com/docs/plugins/api/SlideRowNode

--- a/skills/figma-use/references/text-style-patterns.md
+++ b/skills/figma-use/references/text-style-patterns.md
@@ -180,14 +180,12 @@ await textNode.setTextStyleIdAsync(headingStyle.id);
  */
 async function applyTextStyleToMatchingNodes(styleId, nodeNamePattern) {
   const textNodes = figma.currentPage.findAllWithCriteria({ types: ['TEXT'] });
-  let applied = 0;
-  for (const node of textNodes) {
-    if (node.name.includes(nodeNamePattern)) {
-      await node.setTextStyleIdAsync(styleId);
-      applied++;
-    }
-  }
-  return applied;
+  const matching = textNodes.filter(n => n.name.includes(nodeNamePattern));
+  // Batch the style applications with Promise.all — each setTextStyleIdAsync
+  // call is independent, so awaiting them serially in a for-loop multiplies
+  // the IPC latency by the number of matches.
+  await Promise.all(matching.map(n => n.setTextStyleIdAsync(styleId)));
+  return matching.length;
 }
 ```
 

--- a/skills/figma-use/references/variable-patterns.md
+++ b/skills/figma-use/references/variable-patterns.md
@@ -233,14 +233,18 @@ return results;
 
 ```javascript
 const collections = await figma.variables.getLocalVariableCollectionsAsync();
+// Batch every getVariableByIdAsync into a single Promise.all — sequential
+// awaits inside the loop would serialize one IPC round-trip per variable.
+const allIds = collections.flatMap(c => c.variableIds);
+const allVars = await Promise.all(
+  allIds.map(id => figma.variables.getVariableByIdAsync(id))
+);
 const scopeGroups = {};
-for (const c of collections) {
-  for (const id of c.variableIds) {
-    const v = await figma.variables.getVariableByIdAsync(id);
-    const key = JSON.stringify(v.scopes);
-    if (!scopeGroups[key]) scopeGroups[key] = [];
-    scopeGroups[key].push(v.name);
-  }
+for (const v of allVars) {
+  if (!v) continue;
+  const key = JSON.stringify(v.scopes);
+  if (!scopeGroups[key]) scopeGroups[key] = [];
+  scopeGroups[key].push(v.name);
 }
 return scopeGroups;
 ```
@@ -284,21 +288,23 @@ The async API returns richer data including code syntax and scopes per variable:
  */
 async function listVariableCollectionsAndVariables() {
   const collections = await figma.variables.getLocalVariableCollectionsAsync();
-  const results = [];
-  for (const collection of collections) {
-    const vars = [];
-    for (const id of collection.variableIds) {
-      const v = await figma.variables.getVariableByIdAsync(id);
-      vars.push([v.name, v.id, v.codeSyntax, v.scopes]);
-    }
-    results.push({
-      name: collection.name,
-      id: collection.id,
-      modes: collection.modes.map(m => [m.name, m.modeId]),
-      variables: vars
-    });
-  }
-  return results;
+  // flatMap every variable ID across all collections into one Promise.all,
+  // then look up per-collection from a Map. Avoids nested Promise.all and
+  // still issues every lookup in parallel.
+  const allIds = collections.flatMap(c => c.variableIds);
+  const fetched = await Promise.all(
+    allIds.map(id => figma.variables.getVariableByIdAsync(id))
+  );
+  const byId = new Map(allIds.map((id, i) => [id, fetched[i]]));
+  return collections.map(collection => ({
+    name: collection.name,
+    id: collection.id,
+    modes: collection.modes.map(m => [m.name, m.modeId]),
+    variables: collection.variableIds
+      .map(id => byId.get(id))
+      .filter(v => v)
+      .map(v => [v.name, v.id, v.codeSyntax, v.scopes])
+  }));
 }
 ```
 


### PR DESCRIPTION
## Summary
- Update the Figma MCP plugin skills to v2.2.10.
- Bump version to 2.2.10 across server.json, .claude-plugin/plugin.json, .cursor-plugin/plugin.json, .github/plugin/plugin.json, and gemini-extension.json
- Skill content updates across figma-use, figma-use-figjam, figma-use-slides, figma-generate-design, and figma-generate-library

## Test plan
- [ ] CI passes
- [ ] Plugin manifests load correctly
