### PR TITLE
docs: fix get_metadata page-enumeration guidance (returns only the active page)

### DIFF
--- a/skills/figma-use/references/gotchas.md
+++ b/skills/figma-use/references/gotchas.md
@@ -232,8 +232,8 @@ The same rule generalizes to *any* traversal: scope it to the smallest known anc
 
 A Figma file can have multiple pages (canvas nodes). `get_metadata` only returns the subtree of whichever node you pass it. To get a usable index of every page:
 
-- Call `get_metadata` with **no nodeId** — it returns the document's top-level pages as `{guid, name}` entries (no XML dump). This is the cheapest way to discover pages.
-- For more detail per page (e.g. child counts, top-level node types), fall back to `use_figma`:
+- **Do not rely on `get_metadata` to enumerate pages.** Even with **no nodeId**, its response header reads "Listing the top-level pages of the document" but it returns only the **currently-active page**, not all of them. (Verified 2026-07-10 against a 9-page file: it returned a single page.) The tool's own `description` makes the same incorrect claim, so an agent that trusts it wastes a call every time it needs the full page list.
+- **Enumerate pages with `use_figma` — this is the only reliable way:**
 
 ```js
 const pages = figma.root.children.map(p => `${p.name} id=${p.id} children=${p.children.length}`);


### PR DESCRIPTION
## What

`get_metadata` with no `nodeId` is documented — both in this `figma-use` gotcha and in the tool's own `description` — as returning the document's full list of top-level pages. In practice it returns only the **currently-active page**.

## Reproduction (2026-07-10)

Called `get_metadata` with only a `fileKey` (no `nodeId`) against a file that has 9 pages. Full response:

```
No nodeId was provided. Listing the top-level pages of the document. Call get_metadata again with one of the page ids below (or any node id underneath) to get the XML metadata for that subtree.

Top-level pages of the document:
- 0:1: COVER
```

Only the active page (`COVER`) came back; the other 8 pages (login, project, estimate, …) were omitted. `figma.root.children` via `use_figma` returns all 9.

## Why it matters

The tool `description` says:

> The nodeId parameter is optional: when omitted, the tool returns a list of the top-level pages (guid + name) in the document

An agent that trusts this makes a call expecting all pages, receives one, and has to fall back to `use_figma` + `figma.root.children` anyway — a wasted tool call (and tokens) on **every** session that needs full-document page enumeration.

## This PR

Rewrites the gotcha to describe the actual behavior and points to `use_figma` + `figma.root.children` as the only reliable enumeration path.

```diff
-- Call `get_metadata` with **no nodeId** — it returns the document's top-level pages as `{guid, name}` entries (no XML dump). This is the cheapest way to discover pages.
-- For more detail per page (e.g. child counts, top-level node types), fall back to `use_figma`:
+- **Do not rely on `get_metadata` to enumerate pages.** Even with **no nodeId** ... it returns only the **currently-active page**, not all of them ...
+- **Enumerate pages with `use_figma` — this is the only reliable way:**
```

## Also — server-side fix requested

This PR can only fix the guide doc. The **`get_metadata` tool `description` itself** (server-side, not in this repo) carries the same incorrect claim, and the response header ("Listing the top-level pages of the document") is likewise misleading. Please also either:

1. make `get_metadata` with no `nodeId` actually return **all** top-level pages, or
2. correct the `description` **and** the response header to say it returns only the active page and point to `use_figma` for full enumeration.

Filing this note here because Issues are disabled on this repo — happy to move it wherever the team prefers.
