### PR TITLE
Add Figma Fidelity Guard workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ You can also learn more about the skills included with the Figma plugin for [sup
 This repo also contains standalone workflow skills that are not bundled with the Figma plugin:
 - [`workflow-skills/video-interaction-mapper`](workflow-skills/video-interaction-mapper): Turns UI recordings into annotated Figma storyboards
 - [`workflow-skills/generate-project-plan`](workflow-skills/generate-project-plan): Turn a PRD (plus optional codebase grounding) into a FigJam project plan board
+- [`workflow-skills/figma-fidelity-guard`](workflow-skills/figma-fidelity-guard): Audits incomplete or truncated design context and gates high-fidelity implementation on evidence completeness
 
 # MCP best practices
 

--- a/workflow-skills/figma-fidelity-guard/SKILL.md
+++ b/workflow-skills/figma-fidelity-guard/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: figma-fidelity-guard
+description: Audit and recover incomplete Figma evidence for high-fidelity design-to-code work. Use after or alongside figma-design-to-code when MCP output is truncated, sparse, or contains depth-limit markers; nested instances omit visible text or styles; implementation and screenshot disagree; or complex assets, variables, gradients, masks, effects, overlays, variants, or responsive behavior require an explicit context-completeness gate.
+---
+
+# Figma Fidelity Guard
+
+## Outcome
+
+Build from scoped design evidence instead of visual guesses. Declare the Figma context complete for the target scope before implementing. Treat fidelity as visual structure, content, states, responsive behavior, accessibility, and platform semantics—not blind pixel copying.
+
+## Guardrails
+
+- Resolve the exact Figma file and node from a selection or node-specific URL. Never guess a file key or node ID.
+- This workflow extends `figma-design-to-code`; it does not replace that skill's primary extraction, asset, project-reuse, or implementation rules.
+- Apply this workflow to Figma Design UI. Route FigJam and Slides to their dedicated skills. For Figma Make, use only the context tools supported by that surface; do not assume metadata, code execution, or editable layer access exists.
+- Keep inspection read-only. Never mutate the design while gathering evidence.
+- Apply the workflow proportionally. A simple, complete component may need only design context and its returned screenshot; complex or inconsistent regions require deeper inspection.
+- Minimize calls and returned data. Reuse discovered node IDs and findings instead of repeating full-frame reads.
+- Treat a `depth limit` marker as evidence of an incomplete branch, not as an error to ignore and not as proof that the entire response is unusable.
+- Never declare context complete merely because a tool call succeeded. Completeness is based on whether the evidence accounts for the requested scope.
+
+## Runtime Adapter
+
+- Before calling `get_design_context`, load `figma-design-to-code` through the client's normal skill-loading mechanism. Preserve that skill's required logging and add `figma-fidelity-guard` to `skillNames` when the tool exposes the field.
+- Before calling `use_figma`, load the `figma-use` foundation skill through the client's normal skill-loading mechanism.
+- When the tool exposes a `skillNames` field, pass `figma-fidelity-guard,figma-use` on every `use_figma` call made by this workflow.
+- Use bounded, read-only queries only when `use_figma` is available and the file key is known. Do not make `use_figma` mandatory when primary context is already complete or when the connected MCP surface does not provide it.
+
+## Workflow
+
+### 1. Fix the fidelity contract
+
+Record the target region, platform or viewport, theme or variable mode, component state or variant, expected output, and applicable code design system. If any item would materially change the implementation and cannot be inferred, stop and obtain the missing context.
+
+### 2. Collect the minimum primary evidence
+
+Reuse an existing `get_design_context` result when it targets the exact node, state, and mode. Otherwise load `figma-design-to-code` and call `get_design_context` first for the exact target node.
+
+Use the screenshot returned with design context when present. Call `get_screenshot` for the same node only when the primary result lacks a current render or an independent rendered comparison is needed. Never use metadata or a screenshot as a substitute for primary design context.
+
+If both sources account for the visible design and expose the properties needed for implementation, proceed without metadata or deep traversal.
+
+### 3. Close only demonstrated gaps
+
+Maintain a small gap ledger containing unresolved visible regions, discovered node IDs, visited node IDs, and the evidence still required. Then use only the routes justified by that ledger:
+
+- If design context is too large, truncated, sparse, or internally inconsistent, call `get_metadata` as an index when available and re-fetch only relevant child nodes with `get_design_context`.
+- If a depth-limited branch exposes a child node ID, request that child directly rather than increasing an assumed global depth. Do not hard-code a presumed MCP depth ceiling.
+- If nested node IDs or required properties remain hidden, use a bounded, read-only `use_figma` query against the smallest known ancestor. Enumerate immediate children or return selected scalar fields; never dump the document.
+- If variables or styles affect the mapping, call `get_variable_defs` rather than inferring token values from rendered colors.
+- Search by intersecting bounds only when the screenshot contains visible content not accounted for by the target subtree. Include page-level overlays deliberately and avoid scanning unrelated pages.
+- Use `download_assets` when implementation needs an original or exported asset and the connected server provides it. Otherwise request the exact source or export instead of substituting a screenshot. Treat screenshots and temporary localhost asset references as inspection evidence, not production assets.
+
+Read [deep-inspection.md](references/deep-inspection.md) when context is incomplete or the target contains complex effects, nested instances, masks, overlays, or ambiguous responsive behavior.
+
+Stop expanding when a read adds no new evidence, the relevant visible scope is accounted for, or the agreed inspection budget is exhausted. Report the remaining gap instead of looping.
+
+### 4. Pass the context-completeness gate
+
+Compare the screenshot with the collected node evidence. Account for every visually or behaviorally relevant region in scope, including text, assets, fills, strokes, effects, masks, clipping, layer order, component states, and layout constraints.
+
+For non-trivial UI, publish this concise table before implementation:
+
+| Region or layer | Figma evidence | Key properties or behavior | Code mapping | Confidence or gap |
+|---|---|---|---|---|
+| background | node id/name + screenshot | fill/image/gradient/effective alpha | asset/gradient/token | confirmed |
+| content | node id/name | text, typography, asset, ordering | component/token/asset | confirmed |
+| behavior | frame/instance | constraints, auto layout, variants | responsive/state logic | unresolved node id |
+
+End with exactly one status:
+
+- `Context status: complete for scope`
+- `Context status: partial — <specific gaps>`
+- `Context status: blocked — <required node, permission, or evidence>`
+
+Do not begin a fidelity-sensitive implementation until the status is `complete for scope`. With explicit user authorization, a partial status may support analysis or a clearly labeled prototype, but never an unqualified fidelity claim.
+
+### 5. Map evidence to code
+
+- Reuse existing project components, tokens, typography, and asset conventions when they represent the Figma intent. Verify rather than assume that a Figma variable maps to a code token. If no suitable token exists, preserve the measured value and report the gap; do not expand the design system unless requested.
+- Preserve responsive intent from constraints and auto layout. Validate under finite parent constraints, relevant viewport sizes, text scaling, and realistic content where applicable.
+- Preserve semantics, keyboard or assistive access, platform conventions, and reduced-motion behavior. Document intentional deviations from the visual design instead of degrading usability to achieve a screenshot match.
+- Preserve complex composition when it is material. Compute effective alpha only for simple parent-opacity and child-paint cases; masks, blend modes, gradients, and filters require structural inspection or rendered comparison.
+
+### 6. Verify proportionally
+
+Keep implementation changes inside the requested scope. Run the project's relevant static checks and focused tests. When practical and authorized, compare implementation and Figma screenshots at the same viewport, state, content, scale, and theme.
+
+Prefer stable assertions for token usage, asset identity, semantics, state behavior, and durable visual structure. Avoid tests coupled only to generated widget or DOM shape. On a mismatch, re-read the smallest implicated Figma region instead of restarting the entire extraction.
+
+## Stop Conditions
+
+Stop and report the exact gap when:
+
+- the target node, state, viewport, or platform is ambiguous
+- a visible screenshot region has no corresponding node or asset evidence
+- truncation, an unexpanded instance, or missing style data remains relevant to the implementation
+- an effect, mask, gradient, or asset would be approximated before its source is inspected
+- a traversal repeats nodes, adds no evidence, or exceeds the agreed inspection budget
+- verification reveals a material mismatch in brightness, layer order, clipping, spacing, typography, state, or responsive behavior
+- continuing would require changing Figma, broadening the code scope, or inventing a design-system rule without authorization

--- a/workflow-skills/figma-fidelity-guard/references/deep-inspection.md
+++ b/workflow-skills/figma-fidelity-guard/references/deep-inspection.md
@@ -1,0 +1,81 @@
+# Deep Inspection Reference
+
+Use this reference only after primary design context and the target screenshot demonstrate a concrete gap.
+
+## Route tools by purpose
+
+| Need | Preferred route | Notes |
+|---|---|---|
+| base design-to-code workflow | `figma-design-to-code` | Load before primary context; this guard owns recovery and completeness verification only |
+| visual appearance | `get_screenshot` | Match the exact target node; inspect a child separately only when needed |
+| implementation context | `get_design_context` | Primary design-to-code source; request exact child nodes when output is large |
+| hierarchy and node IDs | `get_metadata` | Sparse index only; absence of style data is expected; availability varies by MCP surface |
+| variable/style values | `get_variable_defs` | Prefer named variables over sampling rendered pixels |
+| omitted deep properties | `use_figma` | Load `figma-use`; execute bounded, read-only code only when the tool is available |
+| source/exported assets | `download_assets` | Otherwise request an exact source/export rather than using a screenshot |
+
+## Recover a depth-limited branch
+
+Do not retry the same broad request or assume a fixed maximum depth. Use an evidence-driven queue:
+
+1. Record the smallest known ancestor, the missing visible region, and any child IDs already exposed.
+2. Obtain a shallow hierarchy index with `get_metadata` when available.
+3. Add unresolved child IDs to a queue and keep a visited set so no node is fetched twice without a stated reason.
+4. Request `get_design_context` directly for the smallest unresolved child. Compare the result with the same screenshot region.
+5. When child IDs or required properties are still hidden, call `use_figma` on the smallest known ancestor to list immediate descendants or selected fields only.
+6. Continue only while each read adds evidence. Stop with a partial or blocked status when the queue cannot progress, access is unavailable, or the inspection budget is exhausted.
+
+Completion is visual and semantic coverage of the requested scope, not reaching an arbitrary tree depth.
+
+## Detect incomplete context
+
+Treat any of these as a reason for targeted follow-up:
+
+- explicit `depth limit`, truncation, ellipsis, or output-size warning
+- an `INSTANCE`, `FRAME`, `GROUP`, or asset placeholder with visible content missing from the returned representation
+- screenshot text, imagery, edge detail, or overlay absent from the node evidence
+- text content without typography, or styling without the variable/value needed to map it
+- a flattened image reference where implementation requires editable or semantic substructure
+- mutually inconsistent screenshot, metadata, design context, and variable results
+
+Do not interpret sparse metadata as proof that descendants do not exist. Do not interpret a complete-looking instance shell as proof that its visible internals were inspected.
+
+## Keep deep reads bounded and read-only
+
+- Start from the smallest known target node and traverse descendants only within that subtree.
+- Return selected scalar fields and compact paint/effect summaries. Avoid returning full plugin objects, binary data, or the entire document.
+- Filter by node type, name, bounds, or unresolved node IDs before collecting expensive properties.
+- Do not call creation, mutation, deletion, reparenting, detachment, variable-writing, or style-writing APIs during inspection.
+- Do not scan every page. Page context can reset between calls; use one explicitly selected page per query when page access is necessary.
+- Cache node IDs and summarized findings in the working response. Do not repeat identical reads.
+
+## Inspect properties by risk
+
+Collect only fields relevant to the visible layer or implementation decision:
+
+- identity and order: `id`, `name`, `type`, child order, `visible`, `opacity`, `blendMode`
+- geometry: local bounds, `absoluteBoundingBox`, rotation, clipping, constraints, auto-layout sizing and alignment
+- paint: fills, strokes, stroke widths, paint opacity, gradient stops and transforms, bound variables
+- composition: effects, masks, mask type, clipping, blend mode, parent opacity, layer order
+- assets: image hashes, export settings, vector identity, source/export availability
+- text: characters, font family/style/weight, size, line height, letter spacing, alignment, wrapping, fills, text style and bound variables
+- states: component properties, variant values, visibility overrides, interactive or disabled states relevant to scope
+
+For a simple solid layer, record parent opacity, paint opacity, and their product when useful. Do not reduce gradients, masks, blur, blend modes, or overlapping translucent layers to that product.
+
+## Check layout and content behavior
+
+- Distinguish fixed frame coordinates from intended responsive constraints or auto layout.
+- Identify clipping that is intentional at the reference size but unsafe for text scaling or localization.
+- Check narrow and wide finite constraints when the component can be embedded rather than full-screen.
+- Check representative long, empty, malformed, and localized content when the UI receives dynamic data.
+- Inspect relevant component variants instead of inferring pressed, selected, disabled, loading, or error states from one screenshot.
+
+## Resolve disagreements
+
+Use the screenshot as rendered evidence and node properties as structural evidence. Neither source alone overrides the other. When they disagree:
+
+1. verify that both calls targeted the same node, variant, theme, and state
+2. inspect variables, parent opacity, masks, effects, and overlapping nodes
+3. re-read the smallest disputed child
+4. record the unresolved difference instead of averaging or guessing values


### PR DESCRIPTION
## Summary

- add `workflow-skills/figma-fidelity-guard` as an optional escalation workflow for complex design-to-code tasks
- detect truncated, sparse, depth-limited, or internally inconsistent design context
- recover only unresolved branches with targeted child reads and bounded, read-only inspection
- require an explicit context-completeness status before making a high-fidelity implementation claim
- list the workflow in the repository README

## Why

`figma-design-to-code` correctly owns the primary design-to-code flow. Large or deeply nested selections can still return a successful but incomplete representation, for example when visible instance text, styles, effects, or overlays are omitted. In that state, an agent can mistake a partial payload for complete evidence and implement from visual guesses.

This workflow extends rather than replaces `figma-design-to-code`. It is proportional: complete components stop after primary context, while demonstrated gaps use a visited-node queue, metadata indexing when available, direct child context reads, and bounded read-only `use_figma` inspection. It deliberately avoids assuming a fixed MCP depth ceiling.

## User impact

Agents get a repeatable way to distinguish complete, partial, and blocked Figma context; avoid repeated broad reads; and preserve visual, responsive, semantic, and asset fidelity without mutating the source design.

## Validation

- `quick_validate.py workflow-skills/figma-fidelity-guard`
- `git diff --check`
- reviewed against the current mandatory `figma-design-to-code` workflow and its `skillNames` logging requirements
