### PR TITLE
Adopt agent-plugins-spec 1.0.0 (additive, no deletions)

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "figma": {
+      "type": "streamable-http",
+      "url": "https://mcp.figma.com/mcp"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "figma",
+  "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
+  "version": "2.2.87",
+  "author": {
+    "name": "Figma",
+    "url": "https://www.figma.com"
+  },
+  "homepage": "https://github.com/figma/mcp-server-guide",
+  "repository": "https://github.com/figma/mcp-server-guide",
+  "keywords": [
+    "figma",
+    "design",
+    "mcp",
+    "ui",
+    "code-connect"
+  ]
+}


### PR DESCRIPTION
## What

Adds the two spec-canonical root files defined by [agent-plugins-spec 1.0.0](https://github.com/agentplugins/agent-plugins-spec) so spec-aware clients discover this plugin via the standard layout:

- **`plugin.json`** — conforms to `plugin.schema.json` 1.0.0 (`$schema` + `name` required). Mirrors the metadata already in `.github/plugin/plugin.json`.
- **`mcp.json`** — conforms to `mcp.schema.json` 1.0.0. Declares the remote Figma MCP server as `type: "streamable-http"` (the spec's constant) pointing at `https://mcp.figma.com/mcp`.

## Why

Cross-company Agent Plugins spec is being announced; adopting it here is a small, structural change that unifies the plugin folder/JSON layout. The awesome-copilot marketplace listing is unaffected — it continues to resolve to this repo.

## Scope — intentionally additive, nothing deleted

This PR **adds two files and changes/removes nothing**, so no live integration is touched:

- Bundled `skills/`, `workflow-skills/`, `figma-power/` — **kept**.
- Per-client manifests `.claude-plugin/`, `.cursor-plugin/`, `gemini-extension.json` — **kept**.
- Existing `.mcp.json` — **kept as-is** (still `type: "http"` for current VS Code consumption).

Retiring the bundle and unifying the per-client manifests are deliberately left for a **separate follow-up PR**.

## Notes

- The VS Code-specific `_meta` block (tool titles / icon) from `.mcp.json` is **omitted** from `mcp.json`: the spec's `streamable-http` server sets `additionalProperties: false`, so only `type`/`url`/`headers` are permitted. `_meta` remains in `.mcp.json`.
- Both files validated against the 1.0.0 schemas (required fields, allowed keys, `name` pattern, server `type` constant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)