### PR TITLE
Skills v2.2.88

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.87",
+  "version": "2.2.88",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.87",
+  "version": "2.2.88",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.87",
+  "version": "2.2.88",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.2.87",
+  "version": "2.2.88",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.2.87",
+  "version": "2.2.88",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-generate-library/references/component-creation.md
+++ b/skills/figma-generate-library/references/component-creation.md
@@ -164,8 +164,6 @@ label.name = 'label';
 label.fontName = { family: 'Inter', style: 'Medium' };
 label.fontSize = 14;
 label.characters = 'Button';
-label.layoutSizingHorizontal = 'HUG';
-label.layoutSizingVertical = 'HUG';
 
 // Text fill — bound to color variable
 const textPaint = figma.variables.setBoundVariableForPaint(
@@ -175,6 +173,8 @@ const textPaint = figma.variables.setBoundVariableForPaint(
 );
 label.fills = [textPaint];
 comp.appendChild(label);
+label.layoutSizingHorizontal = 'HUG';
+label.layoutSizingVertical = 'HUG';
 
 // --- Icon placeholder (Rectangle for now — will be INSTANCE_SWAP) ---
 const iconBox = figma.createFrame();
@@ -760,8 +760,8 @@ const desc = figma.createText();
 desc.fontName = { family: 'Inter', style: 'Regular' };
 desc.fontSize = 14;
 desc.characters = 'Buttons allow users to take actions with a single tap. Use Primary for the highest-emphasis action on a page, Secondary for supporting actions.';
-desc.layoutSizingHorizontal = 'FILL';
 docFrame.appendChild(desc);
+desc.layoutSizingHorizontal = 'FILL';
 
 
 return { docFrameId: docFrame.id };

--- a/skills/figma-generate-library/references/documentation-creation.md
+++ b/skills/figma-generate-library/references/documentation-creation.md
@@ -190,8 +190,8 @@ async function createColorSwatch(parent, varName, variable) {
   label.characters = varName.split('/').pop(); // show leaf name only
   label.fontSize = 10;
   label.fills = [{ type: 'SOLID', color: { r: 0.35, g: 0.35, b: 0.35 } }];
-  label.layoutSizingHorizontal = 'FILL';
   swatchFrame.appendChild(label);
+  label.layoutSizingHorizontal = 'FILL';
 
   // Full path tooltip label (smaller, lighter)
   const pathLabel = figma.createText();
@@ -199,8 +199,8 @@ async function createColorSwatch(parent, varName, variable) {
   pathLabel.characters = varName;
   pathLabel.fontSize = 9;
   pathLabel.fills = [{ type: 'SOLID', color: { r: 0.6, g: 0.6, b: 0.6 } }];
-  pathLabel.layoutSizingHorizontal = 'FILL';
   swatchFrame.appendChild(pathLabel);
+  pathLabel.layoutSizingHorizontal = 'FILL';
 
   parent.appendChild(swatchFrame);
   return swatchFrame;
@@ -246,8 +246,8 @@ async function createColorSection(root, primitiveVars, semanticVars) {
   desc.characters = 'Primitive color palette and semantic color tokens. Semantic tokens reference primitives — always use semantic tokens in components.';
   desc.fontSize = 14;
   desc.fills = [{ type: 'SOLID', color: { r: 0.4, g: 0.4, b: 0.4 } }];
-  desc.layoutSizingHorizontal = 'FILL';
   section.appendChild(desc);
+  desc.layoutSizingHorizontal = 'FILL';
 
   // Primitive swatches row
   const primLabel = figma.createText();
@@ -338,8 +338,8 @@ async function createTypeSpecimen(parent, styleName, fontFamily, fontStyle, font
   nameText.characters = styleName;
   nameText.fontSize = 11;
   nameText.fills = [{ type: 'SOLID', color: { r: 0.55, g: 0.55, b: 0.55 } }];
-  nameText.layoutSizingHorizontal = 'FILL';
   row.appendChild(nameText);
+  nameText.layoutSizingHorizontal = 'FILL';
 
   // Sample text rendered in the actual style
   const specimen = figma.createText();
@@ -348,8 +348,8 @@ async function createTypeSpecimen(parent, styleName, fontFamily, fontStyle, font
   specimen.fontSize = fontSize;
   specimen.lineHeight = { value: lineHeight, unit: 'PIXELS' };
   specimen.fills = [{ type: 'SOLID', color: { r: 0.07, g: 0.07, b: 0.07 } }];
-  specimen.layoutSizingHorizontal = 'FILL';
   row.appendChild(specimen);
+  specimen.layoutSizingHorizontal = 'FILL';
 
   // Specification line
   const specs = figma.createText();
@@ -357,15 +357,15 @@ async function createTypeSpecimen(parent, styleName, fontFamily, fontStyle, font
   specs.characters = `${fontFamily} ${fontStyle} · ${fontSize}px · ${lineHeight}px line height`;
   specs.fontSize = 11;
   specs.fills = [{ type: 'SOLID', color: { r: 0.65, g: 0.65, b: 0.65 } }];
-  specs.layoutSizingHorizontal = 'FILL';
   row.appendChild(specs);
+  specs.layoutSizingHorizontal = 'FILL';
 
   // Divider line
   const divider = figma.createRectangle();
   divider.resize(1280, 1);
   divider.fills = [{ type: 'SOLID', color: { r: 0.9, g: 0.9, b: 0.9 } }];
-  divider.layoutSizingHorizontal = 'FILL';
   row.appendChild(divider);
+  divider.layoutSizingHorizontal = 'FILL';
 
   return row;
 }
@@ -766,8 +766,8 @@ async function createComponentDocFrame(page, componentName, description, usageNo
   title.characters = componentName;
   title.fontSize = 28;
   title.fills = [{ type: 'SOLID', color: { r: 0.07, g: 0.07, b: 0.07 } }];
-  title.layoutSizingHorizontal = 'FILL';
   doc.appendChild(title);
+  title.layoutSizingHorizontal = 'FILL';
 
   // Description
   const descText = figma.createText();
@@ -776,15 +776,15 @@ async function createComponentDocFrame(page, componentName, description, usageNo
   descText.fontSize = 13;
   descText.lineHeight = { value: 20, unit: 'PIXELS' };
   descText.fills = [{ type: 'SOLID', color: { r: 0.35, g: 0.35, b: 0.35 } }];
-  descText.layoutSizingHorizontal = 'FILL';
   doc.appendChild(descText);
+  descText.layoutSizingHorizontal = 'FILL';
 
   // Divider
   const divider = figma.createRectangle();
   divider.resize(280, 1);
   divider.fills = [{ type: 'SOLID', color: { r: 0.88, g: 0.88, b: 0.88 } }];
-  divider.layoutSizingHorizontal = 'FILL';
   doc.appendChild(divider);
+  divider.layoutSizingHorizontal = 'FILL';
 
   // Usage notes
   if (usageNotes.length > 0) {
@@ -802,8 +802,8 @@ async function createComponentDocFrame(page, componentName, description, usageNo
       noteText.fontSize = 12;
       noteText.lineHeight = { value: 18, unit: 'PIXELS' };
       noteText.fills = [{ type: 'SOLID', color: { r: 0.4, g: 0.4, b: 0.4 } }];
-      noteText.layoutSizingHorizontal = 'FILL';
       doc.appendChild(noteText);
+      noteText.layoutSizingHorizontal = 'FILL';
     }
   }
 

--- a/skills/figma-generate-library/scripts/createDocumentationPage.js
+++ b/skills/figma-generate-library/scripts/createDocumentationPage.js
@@ -89,8 +89,8 @@ async function createDocumentationPage(pageName, config) {
   titleNode.characters = config.title
   titleNode.fontSize = 40
   titleNode.fills = [{ type: 'SOLID', color: { r: 0.07, g: 0.07, b: 0.07 } }]
-  titleNode.layoutSizingHorizontal = 'FILL'
   header.appendChild(titleNode)
+  titleNode.layoutSizingHorizontal = 'FILL'
 
   if (config.description) {
     const descNode = figma.createText()
@@ -99,8 +99,8 @@ async function createDocumentationPage(pageName, config) {
     descNode.fontSize = 16
     descNode.lineHeight = { value: 24, unit: 'PIXELS' }
     descNode.fills = [{ type: 'SOLID', color: { r: 0.4, g: 0.4, b: 0.4 } }]
-    descNode.layoutSizingHorizontal = 'FILL'
     header.appendChild(descNode)
+    descNode.layoutSizingHorizontal = 'FILL'
   }
 
   // Sections
@@ -118,8 +118,8 @@ async function createDocumentationPage(pageName, config) {
     sectionHeading.characters = section.name
     sectionHeading.fontSize = 24
     sectionHeading.fills = [{ type: 'SOLID', color: { r: 0.07, g: 0.07, b: 0.07 } }]
-    sectionHeading.layoutSizingHorizontal = 'FILL'
     sectionFrame.appendChild(sectionHeading)
+    sectionHeading.layoutSizingHorizontal = 'FILL'
 
     // Invoke the caller's content function to populate the section
     await section.contentFn(sectionFrame)

--- a/skills/figma-use-slides/references/slide-content.md
+++ b/skills/figma-use-slides/references/slide-content.md
@@ -90,13 +90,15 @@ const container = figma.createAutoLayout("VERTICAL", {
 });
 
 slide.appendChild(container);
-container.layoutSizingHorizontal = "FILL";
+container.resize(slide.width - 80, container.height);
 container.layoutSizingVertical = "HUG";
+container.x = 40;
+container.y = 40;
 
 return { createdNodeIds: [container.id] };
 ```
 
-Remember: `layoutSizingHorizontal/Vertical = 'FILL'` must be set **after** `appendChild`.
+Slides are not auto-layout parents, so direct slide children cannot use `FILL`. Give the container an explicit width instead. For nested children, set `FILL` only after appending them to an auto-layout container.
 
 ## Working with components
 

--- a/skills/figma-use/references/plugin-api-patterns.md
+++ b/skills/figma-use/references/plugin-api-patterns.md
@@ -263,15 +263,16 @@ frame.counterAxisAlignItems = "MAX";     // End
 ### Child Sizing
 
 ```javascript
-// IMPORTANT: FILL can only be set AFTER the child is appended to an auto-layout parent
+// FILL requires an auto-layout parent and must be set after appendChild.
+const parent = figma.createAutoLayout("VERTICAL");
 parent.appendChild(child)
 child.layoutSizingHorizontal = "FILL";   // Stretch to parent
-child.layoutSizingHorizontal = "HUG";    // Shrink to content
-child.layoutSizingHorizontal = "FIXED";  // Manual width
-
-child.layoutSizingVertical = "FILL";
-child.layoutSizingVertical = "HUG";
 child.layoutSizingVertical = "FIXED";
+
+// HUG is valid for nodes with intrinsic content, such as text and auto-layout frames.
+// Append the node to its auto-layout parent before assigning HUG.
+parent.appendChild(textChild);
+textChild.layoutSizingHorizontal = "HUG";
 ```
 
 ### Wrapping (Grid-like Layout)
@@ -286,6 +287,9 @@ frame.counterAxisSpacing = 24;   // Vertical gap (between rows)
 ### Absolute Positioning Within Auto Layout
 
 ```javascript
+// ABSOLUTE also requires the child to be attached to an auto-layout parent first.
+const parent = figma.createAutoLayout("HORIZONTAL");
+parent.appendChild(child);
 child.layoutPositioning = "ABSOLUTE";
 child.constraints = { horizontal: "MAX", vertical: "MIN" };  // Top-right
 child.x = parentWidth - childWidth - 8;


### PR DESCRIPTION
Updates the Figma MCP plugin skills and bumps the release version to **2.2.88**.

## Skills

- `figma-generate-library` — `references/component-creation.md`, `references/documentation-creation.md`, `scripts/createDocumentationPage.js`
- `figma-use-slides` — `references/slide-content.md`
- `figma-use` — `references/plugin-api-patterns.md`

## Version bumps (2.2.87 → 2.2.88)

`server.json`, `gemini-extension.json`, `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.github/plugin/plugin.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
