### PR TITLE
Skills v2.2.90

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.88",
+  "version": "2.2.90",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.88",
+  "version": "2.2.90",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.88",
+  "version": "2.2.90",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.2.88",
+  "version": "2.2.90",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.2.88",
+  "version": "2.2.90",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-use/references/api-reference.md
+++ b/skills/figma-use/references/api-reference.md
@@ -238,9 +238,14 @@ node.remove()
 
 ## Descriptions & Documentation Links
 
+Only access `description` on components and component sets. Accessing it on a
+frame, instance, or other scene node throws instead of returning `undefined`.
+
 ```js
 // Description — plain text, shown in Figma's component panel
-node.description = "A short summary of this component's purpose and usage."
+if (node.type === "COMPONENT" || node.type === "COMPONENT_SET") {
+  node.description = "A short summary of this component's purpose and usage."
+}
 
 // Documentation links — array of {uri, label} shown as clickable links
 componentSet.documentationLinks = [

--- a/skills/figma-use/references/working-with-design-systems/wwds-components.md
+++ b/skills/figma-use/references/working-with-design-systems/wwds-components.md
@@ -20,7 +20,7 @@ Figma has four property types, which can be inspected through `componentProperty
 
 ## Descriptions
 
-Components, component sets, and instances all inherit `PublishableMixin`, which includes a writable `description` string. Setting a description is important for any component intended to be used by others — it appears in Figma's dev mode and component panel, and is surfaced when reading component metadata.
+Components and component sets inherit `PublishableMixin`, which includes a writable `description` string. Frames, instances, and other scene nodes do not; accessing `description` on them throws instead of returning `undefined`. Setting a description is important for any component intended to be used by others — it appears in Figma's dev mode and component panel, and is surfaced when reading component metadata.
 
 Descriptions should explain the component's intent and any non-obvious usage constraints. They are not a substitute for Code Connect annotations, but they are always visible without any tooling setup.
 


### PR DESCRIPTION
Updates the Figma MCP plugin skills and bumps the release version to **2.2.90**.

## Skill changes

- **`figma-use/references/api-reference.md`** — `description` is only safe to access on `COMPONENT` / `COMPONENT_SET`; reading it on a frame, instance, or other scene node throws rather than returning `undefined`. Example now guards on node type.
- **`figma-use/references/working-with-design-systems/wwds-components.md`** — same correction: only components and component sets inherit `PublishableMixin`, not instances.

## Version bumps (2.2.88 → 2.2.90)

- `.claude-plugin/plugin.json`
- `.cursor-plugin/plugin.json`
- `.github/plugin/plugin.json`
- `gemini-extension.json`
- `server.json`
