### PR TITLE
Skills v2.2.91

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.90",
+  "version": "2.2.91",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.90",
+  "version": "2.2.91",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.90",
+  "version": "2.2.91",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.2.90",
+  "version": "2.2.91",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.2.90",
+  "version": "2.2.91",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-use/SKILL.md
+++ b/skills/figma-use/SKILL.md
@@ -25,7 +25,7 @@ IMPORTANT: Whenever you work with design systems, start with [working-with-desig
 1.  **Use `return` to send data back.** The return value is JSON-serialized automatically (objects, arrays, strings, numbers). Do NOT call `figma.closePlugin()` or wrap code in an async IIFE — this is handled for you.
 2.  **Write plain JavaScript with top-level `await` and `return`.** Code is automatically wrapped in an async context. Do NOT wrap in `(async () => { ... })()`.
 3.  `figma.notify()` **throws "not implemented"** — never use it
-3a. **Prefer returned IDs and external state for workflow persistence.** Put human-readable component purpose and usage in the component's `description`. `getSharedPluginData(namespace, key)` and `setSharedPluginData(namespace, key, value)` should almost never be needed; if needed, you must use a stable namespace (at least 3 alphanumeric, `_`, or `.` characters).
+3a. **Return node IDs and keep workflow state outside the Figma file.** Put human-readable component purpose and usage in the component's `description`.
 4.  `console.log()` is NOT returned — use `return` for output
 5.  **Work incrementally in small steps.** Break large operations into multiple `use_figma` calls. Validate after each step. This is the single most important practice for avoiding bugs.
 6.  Colors are **0–1 range** (not 0–255): `{r: 1, g: 0, b: 0}` = red

--- a/skills/figma-use/references/gotchas.md
+++ b/skills/figma-use/references/gotchas.md
@@ -254,13 +254,9 @@ return "Done!"
 
 ## Prefer returned IDs for workflow state
 
-Return node IDs and keep workflow state outside the Figma file. Put human-readable component purpose and usage in `description`. Use shared plugin data only when the user explicitly needs metadata shared across integrations; in that case, use a stable namespace unique to the integration and at least 3 characters long.
+Return node IDs and keep workflow state outside the Figma file. Put human-readable component purpose and usage in `description`.
 
 ```js
-node.setSharedPluginData('my_namespace', 'my_key', 'my_value')
-const val = node.getSharedPluginData('my_namespace', 'my_key')
-
-// ALSO CORRECT — return node IDs and track them across calls
 const rect = figma.createRectangle()
 return { nodeId: rect.id }
 // Then pass nodeId as a string literal in the next use_figma call
@@ -418,23 +414,19 @@ await Promise.all(uniqueFonts.map(f => figma.loadFontAsync(f)))
 
 **Rule: use `findAllWithCriteria({ types: [...] })` for type-based searches. Reserve `findOne` / `findAll(predicate)` for cases the criteria API can't express** — name patterns, regex, capability checks (`'fills' in n`), or any predicate that touches properties the engine doesn't index.
 
-`findAll` and `findOne` walk the entire subtree node-by-node and run a JS predicate on each one. For supported criteria such as type and shared plugin data, use the faster API in this table:
+`findAll` and `findOne` walk the entire subtree node-by-node and run a JS predicate on each one. For supported criteria such as type, use the faster API in this table:
 
 | You want… | DON'T | DO |
 |---|---|---|
 | One specific node, you have its ID | `page.findOne(n => n.id === id)` | `await figma.getNodeByIdAsync(id)` |
 | All nodes of a given type | `page.findAll(n => n.type === 'TEXT')` | `page.findAllWithCriteria({ types: ['TEXT'] })` |
 | Type + a few cheap attributes (`name`, `visible`, etc.) | `page.findAll(n => n.type === 'TEXT' && n.name === 'Title')` | `page.query('TEXT[name=Title]')` (see [SKILL.md → node.query](../SKILL.md#nodequeryselector--css-like-node-search)) |
-| Nodes with shared plugin data | `page.findAll(n => n.getSharedPluginData('ns', 'key'))` | `page.findAllWithCriteria({ sharedPluginData: { namespace: 'ns', keys: ['key'] } })` |
 
-**`types` and `sharedPluginData.keys` are arrays — pass multiple values in a single call instead of issuing N separate ones.** A union over `types` is OR'd; multiple `sharedPluginData.keys` match nodes that carry *any* of the given keys.
+**`types` is an array — pass multiple values in a single call instead of issuing N separate ones.** A union over `types` is OR'd.
 
 ```js
 // Multiple types in one call — returns COMPONENT ∪ COMPONENT_SET in one indexed pass
 page.findAllWithCriteria({ types: ['COMPONENT', 'COMPONENT_SET'] })
-
-// Multiple sharedPluginData keys (under the same namespace)
-page.findAllWithCriteria({ sharedPluginData: { namespace: 'my.namespace', keys: ['key', 'status'] } })
 ```
 
 One more rule applies to any traversal — see also the dedicated [Scope traversal to the smallest known ancestor](#scope-traversal-to-the-smallest-known-ancestor) gotcha below:


### PR DESCRIPTION
Updates the Figma MCP plugin skills and bumps the release version to **2.2.91**.

### Skill changes
- `skills/figma-use/SKILL.md`
- `skills/figma-use/references/gotchas.md`

### Version bumps (2.2.90 → 2.2.91)
- `.claude-plugin/plugin.json`
- `.cursor-plugin/plugin.json`
- `.github/plugin/plugin.json`
- `gemini-extension.json`
- `server.json`
