### PR TITLE
fix: correct relative path to token-creation.md from wwds-variables.md

### DIFF
--- a/skills/figma-use/references/working-with-design-systems/wwds-variables.md
+++ b/skills/figma-use/references/working-with-design-systems/wwds-variables.md
@@ -32,7 +32,7 @@ Code syntax is a surface area in Figma for codebase translation context. You can
 
 ### Scope
 
-`variable.scopes: VariableScope[]` specifies which properties in Figma the variable can be used for. This is important when you create and when you use variables. **Always set specific scopes rather than leaving the default `ALL_SCOPES`** — it pollutes every property picker with irrelevant tokens. The more specific the better. For the canonical scope-to-use-case mapping, see [token-creation.md § Variable Scopes — Complete Reference Table](../../figma-generate-library/references/token-creation.md).
+`variable.scopes: VariableScope[]` specifies which properties in Figma the variable can be used for. This is important when you create and when you use variables. **Always set specific scopes rather than leaving the default `ALL_SCOPES`** — it pollutes every property picker with irrelevant tokens. The more specific the better. For the canonical scope-to-use-case mapping, see [token-creation.md § Variable Scopes — Complete Reference Table](../../../figma-generate-library/references/token-creation.md).
 
 Common scope values:
 


### PR DESCRIPTION
## What

Fixes a broken relative markdown link in `skills/figma-use/references/working-with-design-systems/wwds-variables.md`.

The link to `figma-generate-library/references/token-creation.md` used `../../`, which resolves one directory too high after this file was nested under `working-with-design-systems/`.

Changed to `../../../figma-generate-library/references/token-creation.md`.

## Why

The same href is already correct in `skills/figma-use/references/variable-patterns.md` (one level shallower). Grepped the skills tree — this was the only broken instance.

Destination file exists; target heading is `## 5. Variable Scopes — Complete Reference Table`.
