### PR TITLE
skills: Sync figma-plugin skills and bump to 2.2.101

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.96",
+  "version": "2.2.101",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.96",
+  "version": "2.2.101",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.96",
+  "version": "2.2.101",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.figma.com/mcp",
       "headers": {
-        "X-Figma-Plugin-Bundle": "figma_prod@2_2_96"
+        "X-Figma-Plugin-Bundle": "figma_prod@2_2_101"
       },
       "_meta": {
         "ideToolIconPath": "./Figma Icon (Mono-line black, tight).svg",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.2.96",
+  "version": "2.2.101",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.2.96",
+  "version": "2.2.101",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-design-to-code/SKILL.md
+++ b/skills/figma-design-to-code/SKILL.md
@@ -19,10 +19,23 @@ This skill owns the **workflow** for design-to-code. Parameter mechanics (nodeId
 
 ## Workflow
 
+### Gate Protocol
+
+- Emit exactly three terse gate messages: G1 after design context returns; one combined G2-G4 check before editing; and G5 before finishing. Do not narrate gates between checkpoints.
+- A `PASS` MUST cite evidence produced by the required work. You MUST NOT make tool calls solely to emit a gate.
+- Gather sufficient evidence for the implementation, not exhaustive evidence. If a requirement is unmet, emit `FAIL`, fix it, then restate the gate.
+- You MUST NOT write code until G1 and G2-G4 pass. You MUST NOT finish until G5 passes.
+- Gates are self-checks. You MUST NOT change the implementation solely to produce gate evidence.
+
 ### 1. Call get_design_context first
 
 - You MUST call `get_design_context` on the target node before writing any code. It is your primary tool — a single call returns reference code, a screenshot, and contextual hints.
 - You MUST NOT reach for `get_metadata` or `get_screenshot` as a substitute. Use them only to orient (e.g. picking a node) or to validate, not in place of `get_design_context`.
+- If the response is sparse metadata, request only the visible child regions needed to implement the target, preferably in one parallel batch.
+
+#### G1 - Design Context
+
+G1 PASS - `<target node; one-line summary of retrieved HTML-format design regions>`
 
 ### 2. Treat the output as a reference, not final code
 
@@ -31,12 +44,12 @@ This skill owns the **workflow** for design-to-code. Parameter mechanics (nodeId
 
 ### 3. Reuse what the project already has
 
-- Before writing new code, You MUST check the target project for existing components, layout patterns, and design tokens that match the design intent.
+- Before writing new code, You MUST check likely project-owned paths for existing components, layout patterns, and design tokens that match the design intent.
 - You MUST reuse the project's existing components and tokens instead of generating new equivalents from scratch.
 
 ### 4. Honor the response hints by priority
 
-Apply the hints in this order — earlier sources override later ones:
+You MUST apply only hint sources that are present and relevant, in this order — earlier sources override later ones:
 
 1. **Code Connect snippets** → use the mapped codebase component directly.
 2. **Component documentation links** → follow them for usage and guidelines.
@@ -44,14 +57,35 @@ Apply the hints in this order — earlier sources override later ones:
 4. **Design tokens (CSS variables)** → map them to the project's token system.
 5. **Raw hex / absolute positioning** → loosely structured; lean on the screenshot for intent.
 
+#### G2-G4 - Pre-edit
+
+- **G2:** You MUST identify the target stack and adapt the reference to it.
+- **G3:** You MUST search likely project-owned paths and identify what will be reused.
+- **G4:** You MUST apply present, relevant hints by priority. You MUST NOT search merely to prove a hint is absent.
+
+G2-G4 PASS - `<stack/path; reuse search/result; present hints/application>`
+
 ### 5. Reproduce images and icons faithfully
 
-Images and icons come back as `<img>` elements whose `src` is a remote asset URL (`https://.../api/mcp/asset/...`). Apply these rules as you write the code:
+Images and icons come back as exported assets. Apply these rules as you write the code:
 
-- **Render every icon/image from its exported asset.** Never hand-write or inline `<svg>`/`<path>`, never author your own icon file, never drop an icon or leave a placeholder — you don't have the real vector data, so anything you draw is wrong.
-- **Sourcing:** the asset URL works directly as `src` for an immediate render, but it **expires in ~7 days** — so for code you'll commit, download-and-commit the exact asset bytes, or wire a dynamic content image to the project's data source (API, CDN, or props). Never a file whose contents you authored.
-- **Reuse a project icon component only if its glyph clearly matches** (a name match is not enough); otherwise use the exported asset.
-- **Size explicitly:** a fixed-size container (icons are usually square, e.g. `size-[24px]`, `overflow-clip`) with BOTH width and height set, and size the leaf `<img>` to fill it (`100%` or fixed px) — never `auto`, which blows the image up to its intrinsic size.
+- **Render every icon/image from its exported asset.** Never author, redraw, omit, or replace it with a placeholder or screenshot.
+- **Sourcing:** remote asset URLs expire in ~7 days. For committed code, download the exact bytes or use the project's data source.
+- **Reuse a project icon component only if its glyph clearly matches**; otherwise use the exported asset.
+- **Preserve designed geometry:** You MUST preserve the outer asset box and inner leaf separately, including both dimensions, padding, and aspect ratio.
+- Relative fill sizing is allowed only if you verified the container constrains the leaf; otherwise set both leaf dimensions explicitly. You MUST NOT use `auto` for a fixed-size leaf.
+- You MUST NOT apply one global size to unlike assets or stretch assets through broad descendant rules.
+
+#### G5 - Asset Fidelity
+
+To pass G5:
+- You MUST use the correct source for every asset.
+- You MUST verify one representative of each shared sizing rule and every exception preserves intended outer and leaf dimensions.
+- You MUST NOT pass on source evidence alone when geometry is unverified.
+
+G5 PASS - `<sources; sizing rules and exceptions; rendered or explicit-dimension evidence>`
+
+Otherwise G5 is `FAIL`. You MUST fix it before finishing.
 
 ## Error Recovery
 

--- a/skills/figma-generate-library/references/discovery-phase.md
+++ b/skills/figma-generate-library/references/discovery-phase.md
@@ -490,7 +490,7 @@ GAPS / CONFLICTS NEEDING DECISIONS
 
 WHAT I WON'T BUILD (and why)
   - {item}: already exists in Figma with matching conventions
-  - {item}: not supported as a Figma variable (e.g. z-index, animation timing)
+  - {item}: not supported as a Figma variable (e.g. z-index)
 
 Shall I proceed?
 ```

--- a/skills/figma-generate-library/scripts/createSemanticTokens.js
+++ b/skills/figma-generate-library/scripts/createSemanticTokens.js
@@ -9,8 +9,8 @@
  * @param {Record<string, string>} modeIds - Map of {modeName: modeId} from createVariableCollection.
  * @param {Array<{
  *   name: string,
- *   type: 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN',
- *   values: Record<string, string | number | boolean | {type: 'VARIABLE_ALIAS', id: string}>,
+ *   type: 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN' | 'TIMING' | 'EASING',
+ *   values: Record<string, string | number | boolean | MotionEasing | {type: 'VARIABLE_ALIAS', id: string}>,
  *   scopes?: VariableScope[],
  *   codeSyntax?: {WEB?: string, ANDROID?: string, iOS?: string}
  * }>} tokenMap - Ordered list of token definitions.

--- a/skills/figma-use/references/api-reference.md
+++ b/skills/figma-use/references/api-reference.md
@@ -112,7 +112,7 @@ collection.renameMode(modeId, "Light")
 // Variables
 const variable = figma.variables.createVariable("name", collection, "COLOR")
 //                                                       ^ must be a collection object (passing an ID string is deprecated)
-// resolvedType: "COLOR" | "FLOAT" | "STRING" | "BOOLEAN"
+// resolvedType: "COLOR" | "FLOAT" | "STRING" | "BOOLEAN" | "TIMING" | "EASING"
 variable.setValueForMode(modeId, value)
 
 // Scopes — controls where variable appears in property pickers

--- a/skills/figma-use/references/plugin-api-standalone.d.ts
+++ b/skills/figma-use/references/plugin-api-standalone.d.ts
@@ -5228,6 +5228,28 @@ interface EasingFunctionSpring {
   damping: number
   initialVelocity: number
 }
+interface NormalizedSpring {
+  readonly bounce: number
+}
+interface MotionEasing {
+  readonly type:
+    | 'EASE_IN'
+    | 'EASE_OUT'
+    | 'EASE_IN_AND_OUT'
+    | 'LINEAR'
+    | 'EASE_IN_BACK'
+    | 'EASE_OUT_BACK'
+    | 'EASE_IN_AND_OUT_BACK'
+    | 'CUSTOM_CUBIC_BEZIER'
+    | 'GENTLE'
+    | 'QUICK'
+    | 'BOUNCY'
+    | 'SLOW'
+    | 'CUSTOM_SPRING'
+    | 'HOLD'
+  readonly easingFunctionCubicBezier?: EasingFunctionBezier
+  readonly easingFunctionSpring?: NormalizedSpring
+}
 type OverflowDirection = 'NONE' | 'HORIZONTAL' | 'VERTICAL' | 'BOTH'
 /**
  * @see https://developers.figma.com/docs/plugins/api/Overlay
@@ -10126,12 +10148,12 @@ interface ConnectorNode extends OpaqueNodeMixin, MinimalBlendMixin, MinimalStrok
    */
   clone(): ConnectorNode
 }
-type VariableResolvedDataType = 'BOOLEAN' | 'COLOR' | 'FLOAT' | 'STRING'
+type VariableResolvedDataType = 'BOOLEAN' | 'COLOR' | 'FLOAT' | 'STRING' | 'TIMING' | 'EASING'
 interface VariableAlias {
   type: 'VARIABLE_ALIAS'
   id: string
 }
-type VariableValue = boolean | string | number | RGB | RGBA | VariableAlias
+type VariableValue = boolean | string | number | RGB | RGBA | MotionEasing | VariableAlias
 type VariableScope =
   | 'ALL_SCOPES'
   | 'TEXT_CONTENT'

--- a/skills/figma-use/references/plugin-api-standalone.index.md
+++ b/skills/figma-use/references/plugin-api-standalone.index.md
@@ -266,8 +266,8 @@ type BaseNode   (L10862) = DocumentNode | PageNode | SceneNode
 | `Variable`                    | L10153 | Core variable object                                          |
 | `VariableCollection`          | L10367 | Collection of variables + modes                               |
 | `VariableAlias`               | L10121 | Reference to another variable                                 |
-| `VariableValue`               | L10125 | `boolean \| string \| number \| RGB \| RGBA \| VariableAlias` |
-| `VariableResolvedDataType`    | L10120 | `'BOOLEAN' \| 'COLOR' \| 'FLOAT' \| 'STRING'`                 |
+| `VariableValue`               | L10125 | `boolean \| string \| number \| RGB \| RGBA \| MotionEasing \| VariableAlias` |
+| `VariableResolvedDataType`    | L10120 | `'BOOLEAN' \| 'COLOR' \| 'FLOAT' \| 'STRING' \| 'TIMING' \| 'EASING'` |
 | `VariableDataType`            | L5023  | Includes `'VARIABLE_ALIAS' \| 'EXPRESSION'`                   |
 | `VariableScope`               | L10126 | Where variable can be applied                                 |
 | `CodeSyntaxPlatform`          | L10152 | `'WEB' \| 'ANDROID' \| 'iOS'`                                 |

--- a/skills/figma-use/references/variable-patterns.md
+++ b/skills/figma-use/references/variable-patterns.md
@@ -52,9 +52,22 @@ stringVar.setValueForMode(modeId, "Inter");
 // BOOLEAN
 const boolVar = figma.variables.createVariable("my-flag", collection, "BOOLEAN");
 boolVar.setValueForMode(modeId, true);
+
+// TIMING — for motion animation durations (value in seconds)
+const timingVar = figma.variables.createVariable("motion/duration-fast", collection, "TIMING");
+timingVar.setValueForMode(modeId, 0.2);
+
+// EASING — for motion animation easing curves
+const easingVar = figma.variables.createVariable("motion/ease-out", collection, "EASING");
+easingVar.setValueForMode(modeId, {
+  type: "CUSTOM_CUBIC_BEZIER",
+  easingFunctionCubicBezier: { x1: 0, y1: 0, x2: 0.58, y2: 1 }
+});
 ```
 
 **Note:** Paint colors use `{r, g, b}` (no alpha), but COLOR variable values use `{r, g, b, a}` (with alpha). Don't mix them up.
+
+**Note:** TIMING values are durations in seconds (e.g., `0.2` for 200ms). EASING values use the same shape as keyframe easing objects — see [motion-easing.md](../../figma-use-motion/references/motion-easing.md) for the full easing object shape.
 
 ## Binding Variables to Node Properties
 


### PR DESCRIPTION
Updates the Figma MCP plugin skills and bumps the release version to **2.2.101**.

## Skill content (7 files)
- `figma-design-to-code/SKILL.md`
- `figma-generate-library/references/discovery-phase.md`
- `figma-generate-library/scripts/createSemanticTokens.js`
- `figma-use/references/api-reference.md`
- `figma-use/references/plugin-api-standalone.d.ts`
- `figma-use/references/plugin-api-standalone.index.md`
- `figma-use/references/variable-patterns.md`

## Version bumps to 2.2.101 (6 files)
- `server.json`
- `gemini-extension.json`
- `.claude-plugin/plugin.json`
- `.cursor-plugin/plugin.json`
- `.github/plugin/plugin.json`
- `.mcp.json` — `X-Figma-Plugin-Bundle` header version updated to match the release
