### PR TITLE
Skills v2.2.106

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.96",
+  "version": "2.2.106",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.96",
+  "version": "2.2.106",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.96",
+  "version": "2.2.106",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.figma.com/mcp",
       "headers": {
-        "X-Figma-Plugin-Bundle": "figma_prod@2_2_96"
+        "X-Figma-Plugin-Bundle": "figma_prod@2_2_106"
       },
       "_meta": {
         "ideToolIconPath": "./Figma Icon (Mono-line black, tight).svg",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.2.96",
+  "version": "2.2.106",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.2.96",
+  "version": "2.2.106",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-design-to-code/SKILL.md
+++ b/skills/figma-design-to-code/SKILL.md
@@ -19,10 +19,23 @@ This skill owns the **workflow** for design-to-code. Parameter mechanics (nodeId
 
 ## Workflow
 
+### Gate Protocol
+
+- Emit exactly three terse gate messages: G1 after design context returns; one combined G2-G4 check before editing; and G5 before finishing. Do not narrate gates between checkpoints.
+- A `PASS` MUST cite evidence produced by the required work. You MUST NOT make tool calls solely to emit a gate.
+- Gather sufficient evidence for the implementation, not exhaustive evidence. If a requirement is unmet, emit `FAIL`, fix it, then restate the gate.
+- You MUST NOT write code until G1 and G2-G4 pass. You MUST NOT finish until G5 passes.
+- Gates are self-checks. You MUST NOT change the implementation solely to produce gate evidence.
+
 ### 1. Call get_design_context first
 
 - You MUST call `get_design_context` on the target node before writing any code. It is your primary tool — a single call returns reference code, a screenshot, and contextual hints.
 - You MUST NOT reach for `get_metadata` or `get_screenshot` as a substitute. Use them only to orient (e.g. picking a node) or to validate, not in place of `get_design_context`.
+- If the response is sparse metadata, request only the visible child regions needed to implement the target, preferably in one parallel batch.
+
+#### G1 - Design Context
+
+G1 PASS - `<target node; one-line summary of retrieved HTML-format design regions>`
 
 ### 2. Treat the output as a reference, not final code
 
@@ -31,12 +44,12 @@ This skill owns the **workflow** for design-to-code. Parameter mechanics (nodeId
 
 ### 3. Reuse what the project already has
 
-- Before writing new code, You MUST check the target project for existing components, layout patterns, and design tokens that match the design intent.
+- Before writing new code, You MUST check likely project-owned paths for existing components, layout patterns, and design tokens that match the design intent.
 - You MUST reuse the project's existing components and tokens instead of generating new equivalents from scratch.
 
 ### 4. Honor the response hints by priority
 
-Apply the hints in this order — earlier sources override later ones:
+You MUST apply only hint sources that are present and relevant, in this order — earlier sources override later ones:
 
 1. **Code Connect snippets** → use the mapped codebase component directly.
 2. **Component documentation links** → follow them for usage and guidelines.
@@ -44,14 +57,35 @@ Apply the hints in this order — earlier sources override later ones:
 4. **Design tokens (CSS variables)** → map them to the project's token system.
 5. **Raw hex / absolute positioning** → loosely structured; lean on the screenshot for intent.
 
+#### G2-G4 - Pre-edit
+
+- **G2:** You MUST identify the target stack and adapt the reference to it.
+- **G3:** You MUST search likely project-owned paths and identify what will be reused.
+- **G4:** You MUST apply present, relevant hints by priority. You MUST NOT search merely to prove a hint is absent.
+
+G2-G4 PASS - `<stack/path; reuse search/result; present hints/application>`
+
 ### 5. Reproduce images and icons faithfully
 
-Images and icons come back as `<img>` elements whose `src` is a remote asset URL (`https://.../api/mcp/asset/...`). Apply these rules as you write the code:
+Images and icons come back as exported assets. Apply these rules as you write the code:
 
-- **Render every icon/image from its exported asset.** Never hand-write or inline `<svg>`/`<path>`, never author your own icon file, never drop an icon or leave a placeholder — you don't have the real vector data, so anything you draw is wrong.
-- **Sourcing:** the asset URL works directly as `src` for an immediate render, but it **expires in ~7 days** — so for code you'll commit, download-and-commit the exact asset bytes, or wire a dynamic content image to the project's data source (API, CDN, or props). Never a file whose contents you authored.
-- **Reuse a project icon component only if its glyph clearly matches** (a name match is not enough); otherwise use the exported asset.
-- **Size explicitly:** a fixed-size container (icons are usually square, e.g. `size-[24px]`, `overflow-clip`) with BOTH width and height set, and size the leaf `<img>` to fill it (`100%` or fixed px) — never `auto`, which blows the image up to its intrinsic size.
+- **Render every icon/image from its exported asset.** Never author, redraw, omit, or replace it with a placeholder or screenshot.
+- **Sourcing:** remote asset URLs expire in ~7 days. For committed code, download the exact bytes or use the project's data source.
+- **Reuse a project icon component only if its glyph clearly matches**; otherwise use the exported asset.
+- **Preserve designed geometry:** You MUST preserve the outer asset box and inner leaf separately, including both dimensions, padding, and aspect ratio.
+- Relative fill sizing is allowed only if you verified the container constrains the leaf; otherwise set both leaf dimensions explicitly. You MUST NOT use `auto` for a fixed-size leaf.
+- You MUST NOT apply one global size to unlike assets or stretch assets through broad descendant rules.
+
+#### G5 - Asset Fidelity
+
+To pass G5:
+- You MUST use the correct source for every asset.
+- You MUST verify one representative of each shared sizing rule and every exception preserves intended outer and leaf dimensions.
+- You MUST NOT pass on source evidence alone when geometry is unverified.
+
+G5 PASS - `<sources; sizing rules and exceptions; rendered or explicit-dimension evidence>`
+
+Otherwise G5 is `FAIL`. You MUST fix it before finishing.
 
 ## Error Recovery
 

--- a/skills/figma-generate-design/SKILL.md
+++ b/skills/figma-generate-design/SKILL.md
@@ -454,13 +454,10 @@ For detailed API patterns and gotchas, load these from the [figma-use](../figma-
 
 ## Error Recovery
 
-Follow the error recovery process from [figma-use](../figma-use/SKILL.md#6-error-recovery--self-correction):
+Follow [figma-use error recovery](../figma-use/SKILL.md#7-error-recovery--self-correction):
 
-1. **STOP** on error — do not retry immediately.
-2. **Read the error message carefully** to understand what went wrong.
-3. If the error is unclear, call `get_metadata` or `get_screenshot` to inspect the current file state.
-4. **Fix the script** based on the error message.
-5. **Retry** the corrected script — this is safe because failed scripts are atomic (nothing is created if a script errors).
+- If `safeToRetryWithoutCanvasRead` is `true`, fix the error and retry.
+- If `false`, read the canvas, determine what changed, then make changes.
 
 Because this skill works incrementally (one section per call), errors are naturally scoped to a single section. Previous sections from successful calls remain intact.
 

--- a/skills/figma-generate-diagram/references/workflow.md
+++ b/skills/figma-generate-diagram/references/workflow.md
@@ -114,7 +114,7 @@ Ambiguous request? Pick a reasonable extension, do it, and narrate what you chos
 
 If `use_figma` fails after `generate_diagram` succeeded, the user already has the file link from step 3 of the communication flow. The failure message just needs to tell them the state of the file:
 
-- **Do not** retry in a loop or churn trying to fix it.
+- If `safeToRetryWithoutCanvasRead` is `true`, fix the error and retry. If `false`, read the canvas, determine what changed, then make changes.
 - **Do** report clearly what landed and what didn't. _"The diagram is in the file, but I couldn't add the callout labels — `use_figma` failed with {short error}. You can add them manually or ask me to try again."_
 - Partial progress is still progress. The user can open the file and continue from there.
 

--- a/skills/figma-generate-library/SKILL.md
+++ b/skills/figma-generate-library/SKILL.md
@@ -23,7 +23,6 @@ Before starting a phase:
 - Include every task/subtask that will be attempted in that phase.
 - Include the phase exit criteria.
 - Do not begin mutating work for the phase until this checklist has been posted.
-- If the phase requires explicit approval, ask for approval after the checklist and wait.
 
 During execution:
 - Before each major subsection, post a short update naming the exact section being worked on, using this format:
@@ -39,7 +38,6 @@ At the end of each phase:
   - Decisions or conflicts resolved
   - Remaining risks or follow-ups
 - Then show the required phase artifact for that phase and continue automatically.
-- Only ask for explicit approval after Phase 0 or if a genuine decision fork arises (see [Section 6](#6-decision-forks)). For Phases 1–4, the default is to continue automatically after the summary.
 
 ### Stable Task IDs
 
@@ -305,7 +303,6 @@ Collection: "Spacing"       modes: ["Value"]
 ## 9. Per-Phase Anti-Patterns
 
 **Phase 0 anti-patterns:**
-- ❌ Starting to create anything before scope is locked with user
 - ❌ Ignoring existing file conventions and imposing new ones
 - ❌ Skipping `search_design_system` before planning component creation
 

--- a/skills/figma-generate-library/SKILL.md
+++ b/skills/figma-generate-library/SKILL.md
@@ -325,7 +325,7 @@ Collection: "Spacing"       modes: ["Value"]
 - ❌ Importing remote components then immediately detaching them
 
 **General anti-patterns:**
-- ❌ Retrying a failed script without understanding the error first
+- ❌ Retrying when `safeToRetryWithoutCanvasRead` is `false` before reading the canvas
 - ❌ Using name-prefix matching for cleanup (deletes user-owned nodes)
 - ❌ Building on unvalidated work from the previous step
 - ❌ Parallelizing use_figma calls (always sequential)

--- a/skills/figma-generate-library/references/discovery-phase.md
+++ b/skills/figma-generate-library/references/discovery-phase.md
@@ -458,9 +458,9 @@ Compare what was found in code vs what already exists in Figma:
 - **Conflict:** same name, different value → escalate to user (see section 5)
 - **Figma-only:** exists in Figma but not in code → flag for user, likely skip
 
-### User-Facing Checkpoint Message Template
+### User-Facing Discovery Summary Template
 
-Present this message before proceeding. Never begin Phase 1 without explicit user approval.
+Present this message before proceeding, then continue automatically into Phase 1 unless an unresolved conflict requires a user decision.
 
 ```
 Here's what I found and what I plan to build:
@@ -490,9 +490,7 @@ GAPS / CONFLICTS NEEDING DECISIONS
 
 WHAT I WON'T BUILD (and why)
   - {item}: already exists in Figma with matching conventions
-  - {item}: not supported as a Figma variable (e.g. z-index, animation timing)
-
-Shall I proceed?
+  - {item}: not supported as a Figma variable (e.g. z-index)
 ```
 
 ---

--- a/skills/figma-generate-library/references/error-recovery.md
+++ b/skills/figma-generate-library/references/error-recovery.md
@@ -8,21 +8,12 @@ Protocol for handling failures and incomplete runs across a 20–100+ call desig
 
 ---
 
-## 1. Core Protocol: STOP → Inspect → Fix → Retry
+## 1. Core Protocol
 
-**`use_figma` is atomic — a failed script does not execute.** If a script errors, no changes are made to the file. There are no partial nodes or half-built state from the failed call itself. Retrying after a fix is safe.
+- If `safeToRetryWithoutCanvasRead` is `true`, fix the error and retry.
+- If `false`, stop writes, read the canvas, determine what changed, then make changes.
 
 However, in multi-step workflows (20–100+ calls), **previously successful calls** will have created state that persists. If a workflow is abandoned mid-way, nodes from earlier successful calls remain in the file. The cleanup and idempotency patterns in this document handle that scenario.
-
-The recovery sequence for a failed script:
-
-```
-1. STOP    — Do not run any more use_figma writes.
-2. INSPECT — Read the error message carefully. Optionally call get_metadata or get_screenshot to understand the current file state.
-3. FIX     — Correct the script that failed.
-4. RETRY   — Re-run the corrected script.
-5. PERSIST — Update the state ledger with the outcome.
-```
 
 For **abandoned multi-step workflows** (where you need to roll back nodes from previous *successful* calls), use the cleanup protocol in Section 2.
 
@@ -308,7 +299,7 @@ These can be fixed and retried without affecting already-created entities:
 | Variable binding omission | A fill was hardcoded instead of bound | Resolve the node by its state-ledger ID and re-bind the fill |
 | Wrong variable bound | Bound to wrong variable ID | Re-bind with correct variable ID |
 | Text not visible | Font not loaded before text write | Call `listAvailableFontsAsync()` to verify the font exists, then re-run text creation with `loadFontAsync` |
-| Script timeout | Script exceeded time limit before completing | Script is atomic — nothing was created. Reduce scope (fewer nodes per call) and retry |
+| Script timeout | Script exceeded time limit before completing | Follow `safeToRetryWithoutCanvasRead`; if `false`, inspect before reducing scope and retrying |
 
 ### Structural Corruption (Requires Rollback or Restart)
 
@@ -351,14 +342,8 @@ These errors leave the file in a state where continuing forward is unreliable:
 
 ### Phase 1 fails (variable creation)
 
-Since `use_figma` is atomic, a failed call creates nothing. The most common scenario is that some calls in Phase 1 succeeded (creating some variables) while a later call failed.
-
-Recovery steps:
-1. Run the inventory helper and scope variables by their expected collection and deterministic names
-2. Compare against the plan to identify which variables were successfully created and which are still missing
-3. If a successfully created variable has wrong values, call `variable.remove()` and recreate it
-4. Fix the failed script and retry — it's safe since the failed call created nothing
-5. Do NOT proceed to Phase 2 until ALL planned variables exist with correct scopes and code syntax
+- If `safeToRetryWithoutCanvasRead` is `true`, fix the error and retry.
+- If `false`, inventory variables, determine what changed, then resume idempotently. Do not proceed to Phase 2 until all planned variables are correct.
 
 **The most common Phase 1 failure:** script timeout when creating many variables. Fix: batch variable creation — create at most 20–30 variables per call.
 
@@ -375,34 +360,7 @@ Phase 2 failures rarely require Phase 1 rollback unless the page structure itsel
 
 ### Phase 3 fails (component creation)
 
-This is the most common failure mode in long builds. Since `use_figma` is atomic, a failed call creates nothing — but previous successful calls in the component creation sequence will have created state. Handle by which call in the sequence failed:
-
-```
-If failure in Call 1 (page creation):
-  → Nothing was created. Fix the script and retry.
-
-If failure in Call 2 (doc frame):
-  → Call 1's page exists. Fix Call 2 and retry — idempotency check handles it.
-
-If failure in Call 3 (base component):
-  → Calls 1-2 succeeded. Fix Call 3 and retry.
-
-If failure in Call 4 (variant creation):
-  → Call 3's base component exists. Fix Call 4 and retry.
-  → If you need to restart from Call 3, clean up Call 3's nodes first
-    using cleanupOrphans scoped to the component page.
-
-If failure in Call 5 (combineAsVariants + layout):
-  → Variant ComponentNodes from Call 4 exist but aren't combined yet.
-  → Fix Call 5 and retry.
-  → If the component set was already created by a prior attempt of Call 5
-    that succeeded, remove it first, then re-run.
-If failure in Call 6 (component properties):
-  → The component set already exists and is structurally sound.
-  → Fix Call 6 and retry — addComponentProperty is safe to retry if
-    you first resolve the COMPONENT_SET and check componentPropertyDefinitions there.
-  → Idempotency check: if a UID-suffixed `Label#...` property already exists, skip addComponentProperty.
-```
+This is the most common failure mode in long builds. Previous successful calls persist. If `safeToRetryWithoutCanvasRead` is `false`, inspect the component page and state ledger before resuming idempotently.
 
 **Idempotency for component properties (Call 6 retry):**
 

--- a/skills/figma-generate-library/scripts/createSemanticTokens.js
+++ b/skills/figma-generate-library/scripts/createSemanticTokens.js
@@ -9,8 +9,8 @@
  * @param {Record<string, string>} modeIds - Map of {modeName: modeId} from createVariableCollection.
  * @param {Array<{
  *   name: string,
- *   type: 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN',
- *   values: Record<string, string | number | boolean | {type: 'VARIABLE_ALIAS', id: string}>,
+ *   type: 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN' | 'TIMING' | 'EASING',
+ *   values: Record<string, string | number | boolean | MotionEasing | {type: 'VARIABLE_ALIAS', id: string}>,
  *   scopes?: VariableScope[],
  *   codeSyntax?: {WEB?: string, ANDROID?: string, iOS?: string}
  * }>} tokenMap - Ordered list of token definitions.

--- a/skills/figma-generative-plugins/SKILL.md
+++ b/skills/figma-generative-plugins/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: figma-generative-plugins
+description: "**MANDATORY prerequisite** — load this skill before calling `create_generative_plugin` or `update_generative_plugin`. Use when the user asks to create, author, change, fix, or extend a reusable generative Figma plugin."
+disable-model-invocation: false
+---
+
+# Create and update generative Figma plugins
+
+Load this skill before every `create_generative_plugin` or `update_generative_plugin` call. In user-facing language, call the result a “plugin.” The “generative” qualifier only distinguishes this account-library tool from other plugin systems.
+
+## Preflight
+
+Before authoring, confirm the request fits this surface:
+
+- Plugins run in the Figma Design editor.
+- Every plugin must provide functional UI for its core workflow. A plugin with no configurable inputs still needs a clear primary action and useful status or validation feedback.
+- Never embed API keys, OAuth tokens, signed URLs, or other secrets. Plugin source is readable by people who can access it. For authenticated integrations, stop and offer a static dataset, a public no-auth endpoint, or a different architecture.
+
+## Create workflow
+
+1. Resolve the requested workflow and its useful controls. Ask a concise question only if required inputs or behavior are genuinely ambiguous.
+2. Resolve `planKey`. Reuse one supplied by the user; otherwise call `whoami`. Use the sole eligible plan automatically, or ask the user to choose when several materially different plans are available.
+3. Call `create_generative_plugin` once with a concise name, description, and `planKey`. This creates a runnable square-drawing scaffold, not the requested final plugin.
+4. Call `get_generative_plugin` with the returned `id`, then read every source URI. This establishes the scaffold's manifest, UI message contract, and current TypeScript entrypoint.
+5. Replace the scaffold with complete authored files for the requested behavior and UI.
+6. Call `update_generative_plugin` with the returned `id`, a `files` array containing complete replacements for `code.ts` and, when the UI changes, `ui.html`, plus a specific `commitMessage`. Use `metadata` when changing the name or description.
+
+Never stop after `create_generative_plugin`: the starter must be replaced with the requested experience.
+
+## Update workflow
+
+1. Identify the plugin. If needed, call `list_generative_plugins`, then `get_generative_plugin`.
+2. Read every source URI returned by the get tool before editing. Treat those files as the current source of truth.
+3. Preserve existing UI, controls, relaunch behavior, validation, and user-visible affordances unless the user asks to change them.
+4. Call `update_generative_plugin` with complete replacement content for every changed existing file. Use `{ path: "code.ts", content: "..." }` for the entrypoint and `{ path: "ui.html", content: "..." }` for the UI. Unspecified files are preserved.
+
+## Authoring rules
+
+- Before writing replacement files, read [Plugin source authoring](references/authoring.md). It covers the file replacement contract, UI/message lifecycle, PropsKit controls, dynamic-page compatibility, fonts, relaunch behavior, bounded work, geometry, and Plugin API gotchas.
+- Keep the plugin’s primary action obvious and make invalid selection or input states understandable.
+- `update_generative_plugin` can replace existing `code.ts` and `ui.html` files, but cannot replace `manifest.json` or create new files. Keep `figma.showUI(__html__, ...)` in `code.ts` and replace `ui.html` when the requested workflow needs different controls.
+- Avoid destructive canvas changes unless they are the explicit purpose of the plugin and the UI makes that clear.
+- Do not close before asynchronous work and UI messages have completed.
+- Treat a non-error `update_generative_plugin` result as success. Record the returned version when present; a successful response may omit it.
+- On a build error, use the returned compiler output to make the smallest source correction and retry once. If it still fails, surface the error instead of repeatedly rewriting the plugin.
+
+## Completion
+
+Report the plugin name and id, plus the returned version when present and a short description of its UI and primary action.

--- a/skills/figma-generative-plugins/SKILL.md
+++ b/skills/figma-generative-plugins/SKILL.md
@@ -46,4 +46,8 @@ Never stop after `create_generative_plugin`: the starter must be replaced with t
 
 ## Completion
 
-Report the plugin name and id, plus the returned version when present and a short description of its UI and primary action.
+Report the plugin name and id, plus the returned version when present and a short description of its UI and primary action. Construct and include a clickable URL that opens a new Design file with the unpublished plugin ready to try, using the exact plugin id as `try-tool-resource-content-id`:
+
+`https://www.figma.com/file/new?try-tool-resource-content-id=<id>&try-tool-resource-type=gen_tool&type=design&mode=design`
+
+After presenting the new-file link, ask whether the user wants to open the plugin in an existing Figma Design file instead. If yes, reuse a file URL already provided or ask for one, then add the same `try-tool-resource-content-id` and `try-tool-resource-type` query parameters to that URL. Never guess the file URL.

--- a/skills/figma-generative-plugins/references/authoring.md
+++ b/skills/figma-generative-plugins/references/authoring.md
@@ -1,0 +1,246 @@
+# Plugin source authoring
+
+Use this reference when producing complete `code.ts` and `ui.html` replacements for `update_generative_plugin`.
+
+## Contents
+
+- [Deployment boundary](#deployment-boundary)
+- [Plan the product contract](#plan-the-product-contract)
+- [Entrypoint and UI lifecycle](#entrypoint-and-ui-lifecycle)
+- [PropsKit UI](#propskit-ui)
+- [Dynamic-page-compatible Plugin API](#dynamic-page-compatible-plugin-api)
+- [Authoring rules](#authoring-rules)
+- [Pre-build checklist](#pre-build-checklist)
+
+## Deployment boundary
+
+The MCP update accepts a `files` array containing complete replacements for existing authored files:
+
+```json
+[
+  { "path": "code.ts", "content": "<complete TypeScript entrypoint>" },
+  { "path": "ui.html", "content": "<complete plugin UI>" }
+]
+```
+
+It can replace `code.ts` and `ui.html`. It cannot replace `manifest.json`, create a missing file, or accept a diff. Unspecified files are preserved, so include only files that changed. A metadata-only update can use an empty `files` array with `metadata.name` and/or `metadata.description`.
+
+After create/get:
+
+1. Read the manifest, UI, and current entrypoint URIs.
+2. Verify the manifest targets `editorType: ["figma"]`, includes functional UI, and uses dynamic-page access.
+3. Preserve the existing UI message contract when it fits the requested workflow.
+4. When different controls are required, replace `ui.html` and update `code.ts` so their message contracts agree.
+5. If the existing manifest itself is incompatible and the requested behavior requires changing it, surface that limitation; `update_generative_plugin` cannot repair it.
+
+Do not add imports, extra source files, build configuration, or dependencies that the tool cannot deploy.
+
+## Plan the product contract
+
+Before coding, define:
+
+- The primary action and whether it creates, transforms, or inspects layers.
+- Required selection and input states.
+- UI controls, defaults, validation, and status copy.
+- Messages sent UI → sandbox and sandbox → UI.
+- Which operations are repeatable and which close the plugin.
+- The exact created/modified layers, placement, selection, and viewport behavior.
+- Maximum expected work and how it is bounded.
+- Whether relaunch data or lightweight persisted preferences are useful.
+
+Every plugin needs functional UI. Even a zero-parameter operation needs a clear primary button plus useful disabled/error/success feedback.
+
+## Entrypoint and UI lifecycle
+
+The sandbox is the only side that can call `figma.*`. The UI iframe is the only side that can use DOM/browser APIs. Communicate exclusively through messages.
+
+`code.ts` owns Plugin API calls and loads the separate UI with `__html__`:
+
+```ts
+const PANEL_WIDTH = 280
+
+type UiMessage =
+  | { type: 'resize'; height: number }
+  | { type: 'run'; count: number }
+
+figma.showUI(__html__, { width: PANEL_WIDTH, height: 240 })
+
+figma.ui.onmessage = async (message: UiMessage) => {
+  if (message.type === 'resize') {
+    figma.ui.resize(PANEL_WIDTH, Math.max(120, Math.min(900, Math.round(message.height))))
+    return
+  }
+  if (message.type === 'run') {
+    // Validate, mutate, report status. Close only for a genuinely one-shot flow.
+  }
+}
+```
+
+`ui.html` owns the DOM and sends messages to the sandbox:
+
+```html
+<!doctype html>
+<html>
+<head>
+  <script>
+    try {
+      window.localStorage.getItem('x')
+    } catch (e) {
+      const store = new Map()
+      const shim = {
+        getItem: (key) => store.has(key) ? store.get(key) : null,
+        setItem: (key, value) => { store.set(key, String(value)) },
+        removeItem: (key) => { store.delete(key) },
+        clear: () => { store.clear() },
+        key: (index) => Array.from(store.keys())[index] ?? null,
+        get length() { return store.size },
+      }
+      Object.defineProperty(window, 'localStorage', { value: shim, configurable: true })
+    }
+  </script>
+</head>
+<body>
+  <div id="plugin-root">
+    <fig-content>
+      <fig-field>
+        <label>Count</label>
+        <fig-input-number id="count" value="3" min="1" max="100"></fig-input-number>
+      </fig-field>
+    </fig-content>
+    <fig-footer>
+      <label id="status">Ready</label>
+      <fig-button id="run" type="submit">Create layers</fig-button>
+    </fig-footer>
+  </div>
+  <script>
+    const post = (message) => parent.postMessage({ pluginMessage: message }, '*')
+    document.getElementById('run').addEventListener('click', () => {
+      post({ type: 'run', count: Number(document.getElementById('count').value) })
+    })
+    const root = document.getElementById('plugin-root')
+    new ResizeObserver(() => {
+      post({ type: 'resize', height: Math.ceil(root.getBoundingClientRect().height) })
+    }).observe(root)
+  </script>
+</body>
+</html>
+```
+
+Do not close the plugin before asynchronous operations and messages finish. Keep it open for repeatable panels; close only after a one-shot action has completed or a terminal error is shown.
+
+## PropsKit UI
+
+Use PropsKit `fig-*` controls rather than raw HTML equivalents where available. Structure the panel as `<fig-content>` followed by `<fig-footer>`.
+
+- Wrap controls in `<fig-field>` with a child `<label>`.
+- Group related controls with `<fig-group name="…">`.
+- Put status and actions in `<fig-footer>`; disable actions when selection/input requirements are unmet.
+- Use sentence case for labels, groups, status, actions, notifications, and relaunch names.
+- Use Figma's canonical property wording when a control maps directly to an editor property.
+- Read `.value` at submit time unless live updates are part of the requested behavior.
+- Prefer `change` over `input` to avoid scenegraph thrashing. For color/fill pickers, read on submit or deliberately listen to both.
+
+Recommended controls:
+
+| Input | Control |
+| --- | --- |
+| Bounded number | `<fig-slider text>` |
+| Numeric input | `<fig-input-number>` |
+| Text | `<fig-input-text>`; add `multiline` for long text |
+| Color | `<fig-input-color picker="figma-native">` |
+| Gradient | `<fig-input-gradient experimental="modern">` |
+| Palette | `<fig-input-palette min="2" max="8">` |
+| Boolean | `<fig-switch>` |
+| Small choice set | `<fig-options options="A, B, C">` |
+| Large choice set | `<fig-dropdown>` with direct `<option>` children |
+| 2D point | `<fig-joystick fields>` |
+| Image upload | `<fig-image upload>` |
+| Other file upload | `<fig-input-file>` |
+| Primary action | `<fig-button type="submit">` in `<fig-footer>` |
+
+PropsKit-specific rules:
+
+- `<fig-options>` receives comma-separated options; do not add child options.
+- `<fig-dropdown>` receives `<option>` children directly; never nest an HTML `<select>`.
+- `<fig-joystick>` values are `"X% Y%"` strings.
+- Color values are hex; convert channels to normalized `0..1` values before creating paints.
+- PropsKit gradient stop positions/opacities are `0..100`; Plugin API values are `0..1`.
+- Use `<fig-image upload>` for previewable images and `<fig-input-file>` for CSV/JSON/text/binary.
+- Style custom elements with Figma tokens (`--figma-color-*`, `--spacer-*`, `--font-family`) rather than fixed colors.
+
+## Dynamic-page-compatible Plugin API
+
+The create scaffold already uses dynamic-page access. Keep source compatible:
+
+- Prefer `getNodeByIdAsync`, `getStyleByIdAsync`, local-style async getters, variable async getters, `getMainComponentAsync`, and `getInstancesAsync`.
+- Use async setters such as `setFillStyleIdAsync`, `setStrokeStyleIdAsync`, `setEffectStyleIdAsync`, `setGridStyleIdAsync`, `setTextStyleIdAsync`, `setReactionsAsync`, and `setVectorNetworkAsync`.
+- `figma.currentPage` is loaded. Before traversing another page's children, call `await page.loadAsync()`.
+- Change pages with `await figma.setCurrentPageAsync(page)`, never assignment.
+- Load all pages only for a true whole-document operation; it can be slow and memory-heavy.
+- Handle every promise. Avoid `forEach(async ...)`; use `for...of` or bounded `Promise.all`.
+- Do not bypass deprecated APIs with `as any` or computed property access.
+
+If the fetched manifest lacks dynamic-page access, write source using the compatible APIs anyway, but do not claim the manifest was migrated—the MCP update cannot modify it.
+
+## Authoring rules
+
+### Fonts
+
+Call `await figma.loadFontAsync(fontName)` before changing text characters or font-dependent properties. For mixed fonts, inspect ranges and load every required face. Do not assume non-default fonts exist; handle unavailable fonts with a useful status/error message.
+
+### Paints and immutable arrays
+
+- Fills, strokes, and effects are immutable arrays: clone, change, and reassign.
+- Colors use normalized `0..1` RGB. Paint alpha belongs in `opacity`.
+- `setBoundVariableForPaint` returns a new paint; capture and reassign it.
+- Gradient values from PropsKit require conversion to Plugin API gradient types and normalized stops.
+
+### Geometry and placement
+
+- Resize with `node.resize(width, height)`; `width` and `height` are read-only.
+- `resize()` may reset auto-layout sizing modes; reapply the intended sizing afterward.
+- Reparenting preserves relative `x`/`y` values. Set coordinates after `appendChild`, `insertChild`, or grouping into a new parent.
+- Place new top-level output near `figma.viewport.center`, not at the page origin.
+- Select/reveal only the meaningful result. Avoid unexpectedly pulling the viewport away from the user's work.
+- Import icons from SVG with `figma.createNodeFromSvg`; do not reconstruct them from rotated primitive lines.
+
+### Selection and validation
+
+- Validate selection count and layer capabilities before mutating.
+- Use capability guards such as `'fills' in node`; assigning unsupported fields throws.
+- Disable UI actions when possible and revalidate in the sandbox because selection can change after the panel renders.
+- Preserve unrelated children and properties. Track and update only output owned by the plugin.
+- Make destructive behavior explicit in the UI and user-facing copy.
+
+### Bounded work
+
+- Clamp user-supplied counts and dimensions.
+- Avoid unbounded traversal or quadratic pairwise work.
+- For large operations, process in chunks and send progress/status messages.
+- Do not use authenticated network calls or embed secrets. Source is readable to people with access.
+- Public no-auth endpoints are acceptable only when the request genuinely requires them and the endpoint permits browser access.
+
+### Relaunch and persistence
+
+Every plugin must be re-runnable. Call `figma.root.setRelaunchData(...)` when the plugin opens so it remains discoverable when nothing is selected. After a run creates or modifies a layer, also attach relaunch data to the outermost affected layer—such as the selected parent or newly created top-level frame—not each generated child.
+
+Persist only small, non-sensitive preferences with plugin data. Do not persist uploaded files, credentials, stale selection-derived IDs, or destructive confirmations. Keep schemas versioned and tolerate missing/old data.
+
+## Pre-build checklist
+
+Before calling `update_generative_plugin`, check:
+
+1. Every `files` entry contains complete replacement content for existing `code.ts` or `ui.html`.
+2. The fetched manifest constraints are understood and no undeployable manifest or new-file changes are implied.
+3. The plugin has functional UI and a clear primary action.
+4. UI and sandbox message types agree exactly.
+5. Input and selection states are validated on both sides where appropriate.
+6. Every async API is awaited and dynamic-page rules are followed.
+7. Fonts are loaded before text mutation.
+8. Paint arrays are cloned/reassigned and colors are normalized.
+9. Reparented/new output has intentional coordinates and viewport placement.
+10. Work is bounded and no secrets are embedded.
+11. Success/error/status behavior is user-visible and uses “plugin” and “layer,” not internal jargon.
+12. The plugin stays open or closes according to the actual interaction model.
+
+On a build error, fix the reported source issue with the smallest change and retry once.

--- a/skills/figma-shaders/SKILL.md
+++ b/skills/figma-shaders/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: figma-shaders
+description: "**MANDATORY prerequisite** — load this skill before calling `create_shader` or `update_shader`. Use when the user asks to create, author, change, fix, or iterate on a shader effect, shader fill, custom effect, custom fill, or procedural shader in Figma."
+disable-model-invocation: false
+---
+
+# Create and update Figma shaders
+
+Load this skill before every `create_shader` or `update_shader` call. It covers account-library shader authoring through the Figma MCP server. Reading or applying an existing shader does not require this skill.
+
+Shaders have two kinds:
+
+- `effect` samples and transforms the rendered layer beneath it. Use it for blur, distortion, glow, color grading, pixelation, halftone, or other post-processing.
+- `fill` generates pixels without an input raster. Use it for gradients, patterns, noise, textures, and procedural backgrounds.
+
+Do not silently switch kinds during an update. The `kind` passed to `update_shader` must match the existing shader.
+
+## Create workflow
+
+1. Decide whether the request is an effect or fill. Ask only when the visual intent does not resolve the distinction.
+2. Resolve `planKey`. Reuse one supplied by the user; otherwise call `whoami`. Use the sole eligible plan automatically, or ask the user to choose when several materially different plans are available.
+3. Call `create_shader` once with a concise name, description, selected `kind`, and `planKey`. This creates a starter scaffold, not the requested final shader.
+4. Call `get_shader` with the returned `id`, then read every source URI. If the client cannot read MCP resources, call `get_shader` with `includeSource: true` instead. This establishes the runtime imports and the scaffold's fixed metadata contract.
+5. Author the complete replacement `main.ts` for the requested result.
+6. Call `update_shader` with the returned `id`, the same `kind`, `files: [{ path: "main.ts", content: "..." }]`, and a specific `commitMessage`. Use `metadata` when changing the name, description, or animation capabilities. Set `metadata.isAnimated: true` when the source reads time-related frame inputs and `metadata.usesMouse: true` when it reads `frame.mousePosition`.
+
+Never stop after `create_shader`: the starter scaffold is only a structural starting point.
+
+## Update workflow
+
+1. Identify the shader with `list_shaders`, then call `get_shader`. Use its `type` (`effect` or `fill`) as the required update kind.
+2. Read every source URI returned by `get_shader` before editing. If the client cannot read MCP resources, call it with `includeSource: true`. Treat those files as the current source of truth.
+3. Preserve existing controls and behavior unless the user asks to change them.
+4. Call `update_shader` with the complete replacement `main.ts` in the `files` array, not a diff or partial fragment. An empty `files` array is valid only for a metadata-only update.
+
+## Authoring rules
+
+- Before writing the `main.ts` replacement, read [Shader source authoring](references/authoring.md). It contains the required module shape, WebGPU lifecycle, supported parameter schemas, effect/fill alpha rules, and WGSL failure checklist.
+- Match animation metadata to the source. Set `metadata.isAnimated: true` if `main.ts` reads `frame.time`, `frame.deltaTime`, or `frame.frame`, and set `metadata.usesMouse: true` if it reads `frame.mousePosition`. Set the corresponding value to `false` when removing the last such use. `update_shader` applies these metadata fields to the fixed `features.json` manifest even though that file cannot be replaced directly.
+- Prefer `frame.time` for animation so skipped frames do not change the result. It is an absolute millisecond clock; convert it to seconds with `Number(frame.time) * 0.001` when useful.
+- Expose controls for values users are likely to tune per layer; hardcode implementation details.
+- Keep numeric ranges bounded and defaults visually useful.
+- For effects, sample the input raster intentionally. For fills, do not assume an input raster exists.
+- Treat a non-error `update_shader` result as success. Record the returned version when present; a successful response may omit it.
+- On a build error, use the returned compiler output to make the smallest source correction and retry once. If it still fails, surface the error instead of repeatedly rewriting the shader.
+- If the tool reports that animation or mouse input is unavailable, treat that as a terminal capability gate: do not retry or attempt to bypass it. Offer to author a static shader whose exposed properties can be keyframed in Motion mode instead.
+
+## Completion
+
+Report the shader name, kind, and id, plus the returned version when present. Briefly identify the controls or behavior that were added.

--- a/skills/figma-shaders/SKILL.md
+++ b/skills/figma-shaders/SKILL.md
@@ -47,4 +47,10 @@ Never stop after `create_shader`: the starter scaffold is only a structural star
 
 ## Completion
 
-Report the shader name, kind, and id, plus the returned version when present. Briefly identify the controls or behavior that were added.
+Report the shader name, kind, and id, plus the returned version when present. Briefly identify the controls or behavior that were added. Construct and include a clickable URL that opens a new Design file with the unpublished shader ready to try, using the exact shader id as `try-tool-resource-content-id`. Set `try-tool-resource-type` from the shader kind: `gen_effect` for an effect and `gen_fill` for a fill.
+
+`https://www.figma.com/file/new?try-tool-resource-content-id=<id>&try-tool-resource-type=<gen_effect|gen_fill>&type=design&mode=design`
+
+After presenting the new-file link, ask whether the user wants to open the shader in an existing Figma Design file instead. If yes, reuse a file URL already provided or ask for one, then add the same `try-tool-resource-content-id` and resolved `try-tool-resource-type` query parameters to that URL. Never guess the file URL.
+
+Replace the type placeholder with exactly one value; do not include angle brackets or the pipe in the returned URL.

--- a/skills/figma-shaders/references/authoring.md
+++ b/skills/figma-shaders/references/authoring.md
@@ -1,0 +1,248 @@
+# Shader source authoring
+
+Use this reference when producing the complete `main.ts` replacement passed to `update_shader` as `{ path: "main.ts", content: "..." }`. This MCP workflow cannot replace `features.json` directly, but `update_shader.metadata.isAnimated` and `update_shader.metadata.usesMouse` update its capability fields.
+
+## Contents
+
+- [Plan before writing](#plan-before-writing)
+- [Required module contract](#required-module-contract)
+- [Runtime lifecycle](#runtime-lifecycle)
+- [Animation and mouse input](#animation-and-mouse-input)
+- [WebGPU patterns](#webgpu-patterns)
+- [Controls and parameters](#controls-and-parameters)
+- [Effect and fill contracts](#effect-and-fill-contracts)
+- [WGSL rules](#wgsl-rules)
+- [Pre-build checklist](#pre-build-checklist)
+
+## Plan before writing
+
+Resolve these pieces together before coding:
+
+1. Kind: `effect` or `fill`.
+2. Visible controls: names, types, defaults, ranges, units, and which values stay hardcoded.
+3. Capabilities: whether the source reads time or mouse input and which metadata flags that requires.
+4. GPU resources: shader modules, buffers, samplers, textures, layouts, and passes.
+5. Bindings: every WGSL binding must match the JavaScript bind group.
+6. Uniform layout: field order, padding, and total byte size.
+7. Alpha contract: premultiplied for effects, straight for fills.
+
+Do not write until the controls, uniforms, WGSL bindings, and JavaScript resources agree.
+
+## Required module contract
+
+Author valid TypeScript. The build runs TypeScript and ESLint in process, so type annotations and normal function-local declarations are supported.
+
+```javascript
+import { defineProperties } from "figma:shaders"
+
+export default function Effect() {}
+
+export function setup(device, frame) {
+  // Compile shader modules and allocate format-independent GPU resources.
+  // Store persistent values on frame.state.
+}
+
+export function render(device, frame) {
+  // Read frame.params, write uniforms, encode passes, and submit.
+}
+
+defineProperties(Effect, {
+  // User-editable controls.
+})
+```
+
+Rules:
+
+- The only allowed import is `defineProperties` from `figma:shaders`.
+- Keep `defineProperties` at module scope.
+- Do not declare module-scope `var`, `let`, or `const`; the runtime strips top-level declarations and the build rejects them. Put runtime constants inside `setup`/`render` or on `frame.state`.
+- Shader entry points are `vs_main` and `fs_main`; compute conventionally uses `main`.
+- Every complete WGSL module string begins with `diagnostic(off,derivative_uniformity);` as its first non-empty declaration.
+- Uniform buffer sizes are multiples of 16 bytes.
+- Buffers written by `queue.writeBuffer` need `GPUBufferUsage.COPY_DST`.
+- Textures written by `writeTexture` need `GPUTextureUsage.COPY_DST`.
+- Build pipelines lazily in `render()` and cache them by `frame.output.format`. Never hardcode `rgba8unorm`.
+
+## Runtime lifecycle
+
+`device` is a real `GPUDevice`. `frame` provides:
+
+| Field | Meaning |
+| --- | --- |
+| `frame.input` | Input `GPUTexture` or `null`. Effects may sample it; fills must not. |
+| `frame.output` | Target texture. Render into `frame.output.createView()`. |
+| `frame.params` | Values declared by `defineProperties`. |
+| `frame.state` | Persistent mutable bag for modules, buffers, samplers, layouts, and pipelines. |
+| `frame.time` | Absolute animation clock in milliseconds. |
+| `frame.deltaTime` | Milliseconds since the previous rendered frame. |
+| `frame.frame` | Zero-based rendered-frame counter. |
+| `frame.mousePosition` | Layer-local mouse position. |
+
+Use `frame.output.width` and `frame.output.height` for dimensions. Allocate format-independent resources once in `setup`. Write live params into buffers and construct input-dependent bind groups in `render`, because the input texture may be recreated.
+
+Available JavaScript includes WebGPU enums, `Float32Array`, integer typed arrays, `Math`, collections, JSON, and promises. There is no DOM, `window`, `document`, `navigator`, `fetch`, console, timer, animation-frame, microtask, `Float64Array`, or `Float16Array`. Use `Math.sin`, `Math.max`, and similar JavaScript forms—not bare WGSL-style math in JavaScript.
+
+## Animation and mouse input
+
+Animation and mouse-driven shaders require source and manifest metadata to agree:
+
+- If the source reads `frame.time`, `frame.deltaTime`, or `frame.frame`, pass `metadata: { isAnimated: true }` to `update_shader`.
+- If the source reads `frame.mousePosition`, pass `metadata: { usesMouse: true }`.
+- When removing the last use of one capability, pass its metadata value as `false`. Omitted metadata preserves the existing manifest value.
+
+Prefer the absolute `frame.time` clock over accumulating `frame.deltaTime` in `frame.state`; absolute time remains stable when rendering skips frames.
+
+`frame.mousePosition.x` and `.y` are local layer pixels. Normalize coordinates against the output dimensions when the visual should resize with the layer.
+
+## WebGPU patterns
+
+Prefer a six-vertex fullscreen quad with interleaved clip-space position and UV:
+
+```javascript
+frame.state.quad = device.createBuffer({
+  size: 6 * 4 * 4,
+  usage: GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+})
+new Float32Array(frame.state.quad.getMappedRange()).set([
+  -1, -1, 0, 1,  1, -1, 1, 1,  -1, 1, 0, 0,
+  -1, 1, 0, 0,   1, -1, 1, 1,   1, 1, 1, 0,
+])
+frame.state.quad.unmap()
+```
+
+Its vertex layout is:
+
+```javascript
+buffers: [{
+  arrayStride: 16,
+  attributes: [
+    { shaderLocation: 0, format: "float32x2", offset: 0 },
+    { shaderLocation: 1, format: "float32x2", offset: 8 },
+  ],
+}]
+```
+
+Create the render pipeline only when the output format changes:
+
+```javascript
+if (frame.state.pipelineFormat !== frame.output.format) {
+  frame.state.pipeline = device.createRenderPipeline({
+    layout: "auto",
+    vertex: {
+      module: frame.state.shaderModule,
+      entryPoint: "vs_main",
+      buffers: [{
+        arrayStride: 16,
+        attributes: [
+          { shaderLocation: 0, format: "float32x2", offset: 0 },
+          { shaderLocation: 1, format: "float32x2", offset: 8 },
+        ],
+      }],
+    },
+    fragment: {
+      module: frame.state.shaderModule,
+      entryPoint: "fs_main",
+      targets: [{ format: frame.output.format }],
+    },
+    primitive: { topology: "triangle-list" },
+  })
+  frame.state.pipelineFormat = frame.output.format
+}
+```
+
+Allocate uniform buffers once and write them every render. Prefer `vec4f` slots so padding is explicit:
+
+```javascript
+frame.state.uniforms = device.createBuffer({
+  size: 16,
+  usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+})
+device.queue.writeBuffer(
+  frame.state.uniforms,
+  0,
+  new Float32Array([frame.params.amount, frame.output.width, frame.output.height, 0]),
+)
+```
+
+Build bind groups that contain `frame.input` each render. If compute feeds render, encode both passes on one command encoder before submitting.
+
+## Controls and parameters
+
+Expose values users will tune per layer. Keep implementation details hardcoded inside `setup` or `render`; do not invent module-scope constants.
+
+| Type | Use | Important shape |
+| --- | --- | --- |
+| `boolean` | On/off behavior | `{ type: "boolean", defaultValue: true }` |
+| `string` | Genuine free text only | `{ type: "string", defaultValue: "Hello" }` |
+| `number` slider | Bounded continuous value | Include `min`, `max`, `step`, `control: "slider"` |
+| `number` input | Free numeric value | `control: "input"`, optional `unit` |
+| numeric select | Modes/presets | `control: "select"`, numeric option values `0,1,2...` |
+| `color` | RGBA control | Channels are normalized `0..1` |
+| `gradient` | Two-to-eight color stops | Ordered positions `0..1`; pack a fixed eight-stop uniform plus count |
+| `point` | Center/origin | Prefer `mode: "canvas_and_ui"`, `unit: "%"` |
+| `point-radius` | Center plus radius | Radius percent is relative to the smaller layer dimension |
+| `point-point-line` | Two endpoints | Prefer percent units for resize-relative geometry |
+| `point-angle-radius` | Polar control | Angle is degrees |
+| `color-point` | Coupled position and color | Prefer over separate controls for one visual feature |
+
+Dropdowns must be numeric selects. Do not use a string with `control: "select"`; it becomes unstable after edits.
+
+Percent positions are layer-relative and should be divided by 100 for UVs. Pixel values are absolute local pixels and do not scale with layer resizing.
+
+## Effect and fill contracts
+
+### Effects
+
+- Guard `frame.input == null` before calling `createView()`.
+- Input and output use premultiplied alpha. When changing opacity, scale the full RGBA value, not alpha alone.
+- Clamp offset UVs before sampling unless transparent out-of-bounds reads are intentional.
+
+```wgsl
+let opacity = 0.5;
+color *= opacity;
+```
+
+### Fills
+
+- Do not bind or sample `frame.input`.
+- Output uses straight alpha. Scale only the alpha channel when changing opacity.
+
+```wgsl
+let opacity = 0.5;
+color.a *= opacity;
+```
+
+## WGSL rules
+
+- `let` is immutable; use `var` for mutated values and accumulators.
+- Do not use function-scope `const`.
+- Do not assign multi-component swizzles. Replace the entire vector.
+- Array literals use `array(v1, v2)`, not `[v1, v2]`.
+- Matrices are constructed from columns.
+- `select(falseValue, trueValue, condition)` uses the opposite ordering from a C ternary.
+- Avoid reserved or ambiguous names such as `texture`, `sampler`, `sample`, `min`, `max`, `meta`, and WGSL keywords.
+- Use WGSL builtins such as `@builtin(position)`; never use GLSL `gl_*` names.
+- Use `textureSample` for filtered normalized UV sampling and `textureLoad` for integer texels.
+- `textureSample`, derivatives, and gathers must execute in uniform control flow. For a sample needed inside a per-fragment branch, sample first and use `select`, or use `textureSampleLevel(..., 0.0)`/`textureLoad` deliberately.
+- Fixed-bound loops are preferable. Avoid per-pixel loop bounds or breaks around implicit-derivative sampling.
+
+## Pre-build checklist
+
+Before calling `update_shader` with `files: [{ path: "main.ts", content: source }]`, check:
+
+1. Kind matches the existing resource.
+2. Source is the complete module, not a diff.
+3. `metadata.isAnimated` matches any use of `frame.time`, `frame.deltaTime`, or `frame.frame`.
+4. `metadata.usesMouse` matches any use of `frame.mousePosition`.
+5. Time values are treated as milliseconds and preferably derive from the absolute clock.
+6. No top-level runtime declarations.
+7. Bindings and bind-group entries match exactly.
+8. Uniform sizes and writes match and are 16-byte aligned.
+9. Pipelines track `frame.output.format`.
+10. Effects guard and sample input; fills never bind input.
+11. Alpha handling matches the kind.
+12. WGSL starts with the diagnostic directive and uses valid entrypoint names.
+13. No mutated `let`, swizzle assignment, bracket array literal, GLSL builtin, or non-uniform implicit-derivative sample.
+
+On a build error, fix the specific compiler failure with the smallest change and retry once.

--- a/skills/figma-use-figjam/SKILL.md
+++ b/skills/figma-use-figjam/SKILL.md
@@ -41,7 +41,7 @@ Every FigJam text mutation (sticky/shape/label/table cell/connector text, standa
 
 ## Adding Images to a FigJam Board
 
-**`upload_assets` is the ONLY supported way to add images to a FigJam file.** Do NOT use `figma.createImage()` or `figma.createImageAsync()` from inside `use_figma` — they are unsupported as image-upload entry points in FigJam. Call `upload_assets` with the FigJam `fileKey`; the tool returns single-use upload URLs that you POST raw image bytes to, and the image is committed and placed automatically. Pass `nodeId` (with `count: 1`) to attach the upload to an existing FigJam node as a fill; omit `nodeId` to drop the image onto the board as a new layer.
+**`upload_assets` is the ONLY supported way to add images to a FigJam file.** Call `upload_assets` with the FigJam `fileKey`; the tool returns single-use upload URLs that you POST raw image bytes to, and the image is committed and placed automatically. Pass `nodeIds` (with one entry per upload) to attach uploads to existing FigJam nodes as fills; omit `nodeIds` to drop the images onto the board as new layers.
 
 For the full request/response shape, see [figma-use → api-reference.md → Images](../figma-use/references/api-reference.md#images).
 

--- a/skills/figma-use-slides/references/slide-content.md
+++ b/skills/figma-use-slides/references/slide-content.md
@@ -71,7 +71,7 @@ return { createdNodeIds: [rect.id] };
 
 ## Adding images to a slide
 
-**`upload_assets` is the ONLY supported way to put an image on a slide.** Do NOT use `figma.createImage()` or `figma.createImageAsync()` from inside `use_figma` — they are unsupported as image-upload entry points in Slides. Call `upload_assets` with the Slides `fileKey`; the tool returns single-use upload URLs that you POST raw image bytes to, and the image is committed and placed automatically. Pass `nodeId` (with `count: 1`) to attach the upload to an existing slide node as a fill (e.g. a rectangle already on the slide); omit `nodeId` to drop the image onto the slide as a new layer.
+**`upload_assets` is the ONLY supported way to put images on slides.** Call `upload_assets` with the Slides `fileKey`; the tool returns single-use upload URLs that you POST raw image bytes to, and each image is committed and placed automatically. Pass `nodeIds` (with one entry per upload) to attach uploads to existing slide nodes as fills (e.g. rectangles already on the slide); omit `nodeIds` to drop the images onto slides as new layers.
 
 For the full request/response shape, see [figma-use → api-reference.md → Images](../../figma-use/references/api-reference.md#images).
 

--- a/skills/figma-use/SKILL.md
+++ b/skills/figma-use/SKILL.md
@@ -38,7 +38,7 @@ IMPORTANT: Whenever you work with design systems, start with [working-with-desig
 12a. **Use auto-layout for containers that hold related children.** When children have a structural relationship — stacked, side-by-side, aligned, gapped, hugged — wrap them in `figma.createAutoLayout()`, not `figma.createFrame()` with absolute `x`/`y`. Absolute coordinates govern where a container sits on the canvas; auto-layout governs how its children relate inside it. Skipping the container leaves no protection against text reflow, content changes, or overlap.
 12b. **`layoutSizing*` and `*AxisSizingMode` are different enums — don't cross them.** `layoutSizingHorizontal`/`layoutSizingVertical` (set on a **child**) take `'FIXED'|'HUG'|'FILL'`; `primaryAxisSizingMode`/`counterAxisSizingMode` (set on the **frame** itself) take `'FIXED'|'AUTO'`. So `layoutSizingVertical = 'AUTO'` is invalid (use `'HUG'`), and `counterAxisSizingMode = 'FILL'` throws `Expected 'FIXED' | 'AUTO', received 'FILL'` (use `'FIXED'`/`'AUTO'`). Two more errors from the same setter — `Error: in set_layoutSizingHorizontal: node must be an auto-layout frame or a child of an auto-layout frame` and `Error: in set_layoutSizingHorizontal: FILL can only be set on children of auto-layout frames` — mean the node isn't in an auto-layout context yet; **recommendation: make the parent auto-layout (`figma.createAutoLayout()`) and `appendChild` the node before setting** (see Rule 12). See [Gotchas](references/gotchas.md#layoutsizing-vs-axissizingmode-two-different-sizing-enums).
 13. **Position new top-level nodes away from (0,0).** Nodes appended directly to the page default to (0,0). Scan `figma.currentPage.children` to find a clear position (e.g., to the right of the rightmost node). This only applies to page-level nodes — nodes nested inside other frames or auto-layout containers are positioned by their parent. See [Gotchas](references/gotchas.md).
-14. **On `use_figma` error, STOP. Do NOT immediately retry.** Failed scripts are **atomic** — if a script errors, it is not executed at all and no changes are made to the file. Read the error message carefully, fix the script, then retry. See [Error Recovery](#6-error-recovery--self-correction).
+14. **On `use_figma` error, obey `safeToRetryWithoutCanvasRead`.** If `true`, fix the error and retry. If `false`, read the canvas, determine what changed, then make changes. See [Error Recovery](#7-error-recovery--self-correction).
 15. **MUST `return` ALL created/mutated node IDs.** Whenever a script creates new nodes or mutates existing ones on the canvas, collect every affected node ID and return them in a structured object (e.g. `return { createdNodeIds: [...], mutatedNodeIds: [...] }`). This is essential for subsequent calls to reference, validate, or clean up those nodes.
 16. **Always set `variable.scopes` explicitly when creating variables.** The default `ALL_SCOPES` pollutes every property picker — almost never what you want. Use specific scopes like `["FRAME_FILL", "SHAPE_FILL"]` for backgrounds, `["TEXT_FILL"]` for text colors, `["GAP"]` for spacing, etc. See [variable-patterns.md](references/variable-patterns.md) for the full list.
 17. **`await` every Promise.** Never leave a Promise unawaited — unawaited async calls (e.g. `figma.loadFontAsync(...)` without `await`, or `figma.setCurrentPageAsync(page)` without `await`) will fire-and-forget, causing silent failures or race conditions. The script may return before the async operation completes, leading to missing data or half-applied changes.
@@ -311,15 +311,10 @@ Step 5: Final verification
 
 ## 7. Error Recovery & Self-Correction
 
-**`use_figma` is atomic — failed scripts do not execute.** If a script errors, no changes are made to the file. The file remains in the same state as before the call. This means there are no partial nodes, no orphaned elements from the failed script, and retrying after a fix is safe.
-
 ### When `use_figma` returns an error
 
-1. **STOP.** Do not immediately fix the code and retry.
-2. **Read the error message carefully.** Understand exactly what went wrong — wrong API usage, missing font, invalid property value, etc.
-3. **If the error is unclear**, call `get_metadata` or `get_screenshot` to understand the current file state.
-4. **Fix the script** based on the error message.
-5. **Retry** the corrected script.
+- If `safeToRetryWithoutCanvasRead` is `true`, fix the error and retry.
+- If `false`, read the canvas, determine what changed, then make changes.
 
 ### Common self-correction patterns
 | Error message | Likely cause | How to fix |

--- a/skills/figma-use/references/api-reference.md
+++ b/skills/figma-use/references/api-reference.md
@@ -112,7 +112,7 @@ collection.renameMode(modeId, "Light")
 // Variables
 const variable = figma.variables.createVariable("name", collection, "COLOR")
 //                                                       ^ must be a collection object (passing an ID string is deprecated)
-// resolvedType: "COLOR" | "FLOAT" | "STRING" | "BOOLEAN"
+// resolvedType: "COLOR" | "FLOAT" | "STRING" | "BOOLEAN" | "TIMING" | "EASING"
 variable.setValueForMode(modeId, value)
 
 // Scopes — controls where variable appears in property pickers
@@ -264,10 +264,10 @@ const svgNode = figma.createNodeFromSvg('<svg>...</svg>')
 
 **`upload_assets` is the ONLY supported way to upload images into a Figma file** — Design, FigJam, and Slides all share this path. **Do NOT use `figma.createImage()` or `figma.createImageAsync()` from inside `use_figma`.** Both are unsupported as image-upload entry points and will be removed from agent flows; `use_figma` has no network access (so `createImageAsync(src)` cannot fetch URLs) and bytes inside the script are not durable assets in the file.
 
-The `upload_assets` tool is the ONLY supported way. It returns single-use upload URLs that you POST raw bytes to, and the response contains an `imageHash` plus placement details. Server-side commit and canvas placement happen automatically. Pass `nodeId` (with `count: 1`) to set the upload as a fill on an existing node directly, or omit `nodeId` to place the image on the canvas as a new layer.
+The `upload_assets` tool is the ONLY supported way. It returns single-use upload URLs that you POST raw bytes to, and the response contains an `imageHash` plus placement details. Server-side commit and canvas placement happen automatically. Pass `nodeIds` (with one entry per upload) to set uploads as fills on existing nodes directly, or omit `nodeIds` to place the images on the canvas as new layers.
 
 ```text
-upload_assets({ fileKey, count: 1, nodeId, scaleMode: 'FILL' })
+upload_assets({ fileKey, count: 1, nodeIds: [targetNodeId], scaleMode: 'FILL' })
   → { uploads: [{ submitUrl }], instructions: "..." }
 // Then POST the image bytes to submitUrl (multipart/form-data 'file' field
 // preferred — the filename becomes the layer name).

--- a/skills/figma-use/references/plugin-api-standalone.d.ts
+++ b/skills/figma-use/references/plugin-api-standalone.d.ts
@@ -5228,6 +5228,28 @@ interface EasingFunctionSpring {
   damping: number
   initialVelocity: number
 }
+interface NormalizedSpring {
+  readonly bounce: number
+}
+interface MotionEasing {
+  readonly type:
+    | 'EASE_IN'
+    | 'EASE_OUT'
+    | 'EASE_IN_AND_OUT'
+    | 'LINEAR'
+    | 'EASE_IN_BACK'
+    | 'EASE_OUT_BACK'
+    | 'EASE_IN_AND_OUT_BACK'
+    | 'CUSTOM_CUBIC_BEZIER'
+    | 'GENTLE'
+    | 'QUICK'
+    | 'BOUNCY'
+    | 'SLOW'
+    | 'CUSTOM_SPRING'
+    | 'HOLD'
+  readonly easingFunctionCubicBezier?: EasingFunctionBezier
+  readonly easingFunctionSpring?: NormalizedSpring
+}
 type OverflowDirection = 'NONE' | 'HORIZONTAL' | 'VERTICAL' | 'BOTH'
 /**
  * @see https://developers.figma.com/docs/plugins/api/Overlay
@@ -10126,12 +10148,12 @@ interface ConnectorNode extends OpaqueNodeMixin, MinimalBlendMixin, MinimalStrok
    */
   clone(): ConnectorNode
 }
-type VariableResolvedDataType = 'BOOLEAN' | 'COLOR' | 'FLOAT' | 'STRING'
+type VariableResolvedDataType = 'BOOLEAN' | 'COLOR' | 'FLOAT' | 'STRING' | 'TIMING' | 'EASING'
 interface VariableAlias {
   type: 'VARIABLE_ALIAS'
   id: string
 }
-type VariableValue = boolean | string | number | RGB | RGBA | VariableAlias
+type VariableValue = boolean | string | number | RGB | RGBA | MotionEasing | VariableAlias
 type VariableScope =
   | 'ALL_SCOPES'
   | 'TEXT_CONTENT'

--- a/skills/figma-use/references/plugin-api-standalone.index.md
+++ b/skills/figma-use/references/plugin-api-standalone.index.md
@@ -266,8 +266,8 @@ type BaseNode   (L10862) = DocumentNode | PageNode | SceneNode
 | `Variable`                    | L10153 | Core variable object                                          |
 | `VariableCollection`          | L10367 | Collection of variables + modes                               |
 | `VariableAlias`               | L10121 | Reference to another variable                                 |
-| `VariableValue`               | L10125 | `boolean \| string \| number \| RGB \| RGBA \| VariableAlias` |
-| `VariableResolvedDataType`    | L10120 | `'BOOLEAN' \| 'COLOR' \| 'FLOAT' \| 'STRING'`                 |
+| `VariableValue`               | L10125 | `boolean \| string \| number \| RGB \| RGBA \| MotionEasing \| VariableAlias` |
+| `VariableResolvedDataType`    | L10120 | `'BOOLEAN' \| 'COLOR' \| 'FLOAT' \| 'STRING' \| 'TIMING' \| 'EASING'` |
 | `VariableDataType`            | L5023  | Includes `'VARIABLE_ALIAS' \| 'EXPRESSION'`                   |
 | `VariableScope`               | L10126 | Where variable can be applied                                 |
 | `CodeSyntaxPlatform`          | L10152 | `'WEB' \| 'ANDROID' \| 'iOS'`                                 |

--- a/skills/figma-use/references/validation-and-recovery.md
+++ b/skills/figma-use/references/validation-and-recovery.md
@@ -55,14 +55,9 @@ ComponentSet node to verify all 120 children exist with correct names, sizes, an
 
 ## Error Recovery After Failed `use_figma`
 
-**`use_figma` is atomic — failed scripts do not execute.** If a script errors, no changes are made to the file. The file remains in exactly the same state as before the call. There are no partial nodes, no orphaned elements, and retrying after a fix is safe.
-
 **Recovery steps when `use_figma` returns an error:**
-1. **STOP — do NOT immediately fix the code and retry.** Read the error message carefully first.
-2. **Understand the error.** Most errors are caused by wrong API usage, missing font loads, invalid property values, or referencing nodes that don't exist.
-3. **If the error is unclear**, call `get_metadata` or `get_screenshot` to understand the current file state and confirm nothing has changed.
-4. **Fix the script** based on the error message.
-5. **Retry** the corrected script.
+- If `safeToRetryWithoutCanvasRead` is `true`, fix the error and retry.
+- If `false`, read the canvas, determine what changed, then make changes.
 
 ## Recommended Workflow
 
@@ -75,8 +70,6 @@ ComponentSet node to verify all 120 children exist with correct names, sizes, an
 6. get_screenshot   →  Visual check after each major milestone
 
 ⚠️ ON ERROR at any step:
-   a. Read the error message carefully
-   b. get_metadata / get_screenshot  →  If the error is unclear, inspect file state
-   c. Fix the script based on the error
-   d. Retry the corrected script (safe — failed scripts don't modify the file)
+   a. safeToRetryWithoutCanvasRead=true  →  Fix the error and retry
+   b. safeToRetryWithoutCanvasRead=false →  Read the canvas, determine changes, then change
 ```

--- a/skills/figma-use/references/variable-patterns.md
+++ b/skills/figma-use/references/variable-patterns.md
@@ -52,9 +52,22 @@ stringVar.setValueForMode(modeId, "Inter");
 // BOOLEAN
 const boolVar = figma.variables.createVariable("my-flag", collection, "BOOLEAN");
 boolVar.setValueForMode(modeId, true);
+
+// TIMING — for motion animation durations (value in seconds)
+const timingVar = figma.variables.createVariable("motion/duration-fast", collection, "TIMING");
+timingVar.setValueForMode(modeId, 0.2);
+
+// EASING — for motion animation easing curves
+const easingVar = figma.variables.createVariable("motion/ease-out", collection, "EASING");
+easingVar.setValueForMode(modeId, {
+  type: "CUSTOM_CUBIC_BEZIER",
+  easingFunctionCubicBezier: { x1: 0, y1: 0, x2: 0.58, y2: 1 }
+});
 ```
 
 **Note:** Paint colors use `{r, g, b}` (no alpha), but COLOR variable values use `{r, g, b, a}` (with alpha). Don't mix them up.
+
+**Note:** TIMING values are durations in seconds (e.g., `0.2` for 200ms). EASING values use the same shape as keyframe easing objects — see [motion-easing.md](../../figma-use-motion/references/motion-easing.md) for the full easing object shape.
 
 ## Binding Variables to Node Properties
 


### PR DESCRIPTION
Updates the Figma MCP plugin skills and bumps the release version to **2.2.106**.

## New skills

Two skills are added in this update

- `figma-shaders`: guide for creating shader fills and effects through MCP
- `figma-generative-plugins`: guide for creating generative plugins through MCP

Each one contains a `SKILL.md` and a `references/authoring.md`.

## Updated skills

- `figma-use`: `use_figma` retry-safety guidance, motion easing/timing variable types in the standalone typings and `variable-patterns.md`, API reference and validation/recovery refreshes.
- `figma-generate-library`: retry-safety guidance in `error-recovery.md`, discovery-phase and `createSemanticTokens.js` updates for the new motion variable types.
- `figma-design-to-code`, `figma-generate-design`, `figma-generate-diagram`, `figma-use-figjam`, `figma-use-slides` — upstream edits.
