### PR TITLE
Skills v2.2.107

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.106",
+  "version": "2.2.107",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.106",
+  "version": "2.2.107",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.106",
+  "version": "2.2.107",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.figma.com/mcp",
       "headers": {
-        "X-Figma-Plugin-Bundle": "figma_prod@2_2_106"
+        "X-Figma-Plugin-Bundle": "figma_prod@2_2_107"
       },
       "_meta": {
         "ideToolIconPath": "./Figma Icon (Mono-line black, tight).svg",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.2.106",
+  "version": "2.2.107",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.2.106",
+  "version": "2.2.107",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-design-to-code/SKILL.md
+++ b/skills/figma-design-to-code/SKILL.md
@@ -19,23 +19,10 @@ This skill owns the **workflow** for design-to-code. Parameter mechanics (nodeId
 
 ## Workflow
 
-### Gate Protocol
-
-- Emit exactly three terse gate messages: G1 after design context returns; one combined G2-G4 check before editing; and G5 before finishing. Do not narrate gates between checkpoints.
-- A `PASS` MUST cite evidence produced by the required work. You MUST NOT make tool calls solely to emit a gate.
-- Gather sufficient evidence for the implementation, not exhaustive evidence. If a requirement is unmet, emit `FAIL`, fix it, then restate the gate.
-- You MUST NOT write code until G1 and G2-G4 pass. You MUST NOT finish until G5 passes.
-- Gates are self-checks. You MUST NOT change the implementation solely to produce gate evidence.
-
 ### 1. Call get_design_context first
 
 - You MUST call `get_design_context` on the target node before writing any code. It is your primary tool — a single call returns reference code, a screenshot, and contextual hints.
 - You MUST NOT reach for `get_metadata` or `get_screenshot` as a substitute. Use them only to orient (e.g. picking a node) or to validate, not in place of `get_design_context`.
-- If the response is sparse metadata, request only the visible child regions needed to implement the target, preferably in one parallel batch.
-
-#### G1 - Design Context
-
-G1 PASS - `<target node; one-line summary of retrieved HTML-format design regions>`
 
 ### 2. Treat the output as a reference, not final code
 
@@ -44,12 +31,12 @@ G1 PASS - `<target node; one-line summary of retrieved HTML-format design region
 
 ### 3. Reuse what the project already has
 
-- Before writing new code, You MUST check likely project-owned paths for existing components, layout patterns, and design tokens that match the design intent.
+- Before writing new code, You MUST check the target project for existing components, layout patterns, and design tokens that match the design intent.
 - You MUST reuse the project's existing components and tokens instead of generating new equivalents from scratch.
 
 ### 4. Honor the response hints by priority
 
-You MUST apply only hint sources that are present and relevant, in this order — earlier sources override later ones:
+Apply the hints in this order — earlier sources override later ones:
 
 1. **Code Connect snippets** → use the mapped codebase component directly.
 2. **Component documentation links** → follow them for usage and guidelines.
@@ -57,35 +44,14 @@ You MUST apply only hint sources that are present and relevant, in this order �
 4. **Design tokens (CSS variables)** → map them to the project's token system.
 5. **Raw hex / absolute positioning** → loosely structured; lean on the screenshot for intent.
 
-#### G2-G4 - Pre-edit
-
-- **G2:** You MUST identify the target stack and adapt the reference to it.
-- **G3:** You MUST search likely project-owned paths and identify what will be reused.
-- **G4:** You MUST apply present, relevant hints by priority. You MUST NOT search merely to prove a hint is absent.
-
-G2-G4 PASS - `<stack/path; reuse search/result; present hints/application>`
-
 ### 5. Reproduce images and icons faithfully
 
-Images and icons come back as exported assets. Apply these rules as you write the code:
+Images and icons come back as `<img>` elements whose `src` is a remote asset URL (`https://.../api/mcp/asset/...`). Apply these rules as you write the code:
 
-- **Render every icon/image from its exported asset.** Never author, redraw, omit, or replace it with a placeholder or screenshot.
-- **Sourcing:** remote asset URLs expire in ~7 days. For committed code, download the exact bytes or use the project's data source.
-- **Reuse a project icon component only if its glyph clearly matches**; otherwise use the exported asset.
-- **Preserve designed geometry:** You MUST preserve the outer asset box and inner leaf separately, including both dimensions, padding, and aspect ratio.
-- Relative fill sizing is allowed only if you verified the container constrains the leaf; otherwise set both leaf dimensions explicitly. You MUST NOT use `auto` for a fixed-size leaf.
-- You MUST NOT apply one global size to unlike assets or stretch assets through broad descendant rules.
-
-#### G5 - Asset Fidelity
-
-To pass G5:
-- You MUST use the correct source for every asset.
-- You MUST verify one representative of each shared sizing rule and every exception preserves intended outer and leaf dimensions.
-- You MUST NOT pass on source evidence alone when geometry is unverified.
-
-G5 PASS - `<sources; sizing rules and exceptions; rendered or explicit-dimension evidence>`
-
-Otherwise G5 is `FAIL`. You MUST fix it before finishing.
+- **Render every icon/image from its exported asset.** Never hand-write or inline `<svg>`/`<path>`, never author your own icon file, never drop an icon or leave a placeholder — you don't have the real vector data, so anything you draw is wrong.
+- **Sourcing:** the asset URL works directly as `src` for an immediate render, but it **expires in ~7 days** — so for code you'll commit, download-and-commit the exact asset bytes, or wire a dynamic content image to the project's data source (API, CDN, or props). Never a file whose contents you authored.
+- **Reuse a project icon component only if its glyph clearly matches** (a name match is not enough); otherwise use the exported asset.
+- **Size explicitly:** a fixed-size container (icons are usually square, e.g. `size-[24px]`, `overflow-clip`) with BOTH width and height set, and size the leaf `<img>` to fill it (`100%` or fixed px) — never `auto`, which blows the image up to its intrinsic size.
 
 ## Error Recovery
 


### PR DESCRIPTION
This PR reverts the `figma-design-to-code` changes that shipped in v2.2.106 (#95) and bumps to **2.2.107**.