### PR TITLE
mcp: Sync Figma plugin skills v2.2.108

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.107",
+  "version": "2.2.108",
   "author": {
     "name": "Figma"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.107",
+  "version": "2.2.109",
   "author": {
     "name": "Figma"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
-  "version": "2.2.109",
+  "version": "2.2.107",
   "author": {
     "name": "Figma"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.107",
+  "version": "2.2.109",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.107",
+  "version": "2.2.108",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "displayName": "Figma",
-  "version": "2.2.109",
+  "version": "2.2.107",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows",
   "author": {
     "name": "Figma"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.109",
+  "version": "2.2.107",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.107",
+  "version": "2.2.108",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "figma",
   "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-  "version": "2.2.107",
+  "version": "2.2.109",
   "author": {
     "name": "Figma",
     "url": "https://www.figma.com"

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.figma.com/mcp",
       "headers": {
-        "X-Figma-Plugin-Bundle": "figma_prod@2_2_108"
+        "X-Figma-Plugin-Bundle": "prod@2_2_108"
       },
       "_meta": {
         "ideToolIconPath": "./Figma Icon (Mono-line black, tight).svg",

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.figma.com/mcp",
       "headers": {
-        "X-Figma-Plugin-Bundle": "prod@2_2_108"
+        "X-Figma-Plugin-Bundle": "figma_prod@2_2_108"
       },
       "_meta": {
         "ideToolIconPath": "./Figma Icon (Mono-line black, tight).svg",

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.figma.com/mcp",
       "headers": {
-        "X-Figma-Plugin-Bundle": "figma_prod@2_2_108"
+        "X-Figma-Plugin-Bundle": "figma_prod@2_2_107"
       },
       "_meta": {
         "ideToolIconPath": "./Figma Icon (Mono-line black, tight).svg",

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.figma.com/mcp",
       "headers": {
-        "X-Figma-Plugin-Bundle": "figma_prod@2_2_107"
+        "X-Figma-Plugin-Bundle": "figma_prod@2_2_108"
       },
       "_meta": {
         "ideToolIconPath": "./Figma Icon (Mono-line black, tight).svg",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Figma",
-  "version": "2.2.107",
+  "version": "2.2.108",
   "description": "Integrate Figma into your workflow: Generate code from frames, extract design context, retrieve resources, and ensure design system consistency with your codebase",
   "mcpServers": {
     "figma": {

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/figma/mcp-server-guide",
     "source": "github"
   },
-  "version": "2.2.107",
+  "version": "2.2.108",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/figma-design-to-code/SKILL.md
+++ b/skills/figma-design-to-code/SKILL.md
@@ -19,23 +19,10 @@ This skill owns the **workflow** for design-to-code. Parameter mechanics (nodeId
 
 ## Workflow
 
-### Gate Protocol
-
-- Emit exactly three terse gate messages: G1 after design context returns; one combined G2-G4 check before editing; and G5 before finishing. Do not narrate gates between checkpoints.
-- A `PASS` MUST cite evidence produced by the required work. You MUST NOT make tool calls solely to emit a gate.
-- Gather sufficient evidence for the implementation, not exhaustive evidence. If a requirement is unmet, emit `FAIL`, fix it, then restate the gate.
-- You MUST NOT write code until G1 and G2-G4 pass. You MUST NOT finish until G5 passes.
-- Gates are self-checks. You MUST NOT change the implementation solely to produce gate evidence.
-
 ### 1. Call get_design_context first
 
 - You MUST call `get_design_context` on the target node before writing any code. It is your primary tool — a single call returns reference code, a screenshot, and contextual hints.
 - You MUST NOT reach for `get_metadata` or `get_screenshot` as a substitute. Use them only to orient (e.g. picking a node) or to validate, not in place of `get_design_context`.
-- If the response is sparse metadata, request only the visible child regions needed to implement the target, preferably in one parallel batch.
-
-#### G1 - Design Context
-
-G1 PASS - `<target node; one-line summary of retrieved HTML-format design regions>`
 
 ### 2. Treat the output as a reference, not final code
 
@@ -44,12 +31,12 @@ G1 PASS - `<target node; one-line summary of retrieved HTML-format design region
 
 ### 3. Reuse what the project already has
 
-- Before writing new code, You MUST check likely project-owned paths for existing components, layout patterns, and design tokens that match the design intent.
+- Before writing new code, You MUST check the target project for existing components, layout patterns, and design tokens that match the design intent.
 - You MUST reuse the project's existing components and tokens instead of generating new equivalents from scratch.
 
 ### 4. Honor the response hints by priority
 
-You MUST apply only hint sources that are present and relevant, in this order — earlier sources override later ones:
+Apply the hints in this order — earlier sources override later ones:
 
 1. **Code Connect snippets** → use the mapped codebase component directly.
 2. **Component documentation links** → follow them for usage and guidelines.
@@ -57,35 +44,14 @@ You MUST apply only hint sources that are present and relevant, in this order �
 4. **Design tokens (CSS variables)** → map them to the project's token system.
 5. **Raw hex / absolute positioning** → loosely structured; lean on the screenshot for intent.
 
-#### G2-G4 - Pre-edit
-
-- **G2:** You MUST identify the target stack and adapt the reference to it.
-- **G3:** You MUST search likely project-owned paths and identify what will be reused.
-- **G4:** You MUST apply present, relevant hints by priority. You MUST NOT search merely to prove a hint is absent.
-
-G2-G4 PASS - `<stack/path; reuse search/result; present hints/application>`
-
 ### 5. Reproduce images and icons faithfully
 
-Images and icons come back as exported assets. Apply these rules as you write the code:
+Images and icons come back as `<img>` elements whose `src` is a remote asset URL (`https://.../api/mcp/asset/...`). Apply these rules as you write the code:
 
-- **Render every icon/image from its exported asset.** Never author, redraw, omit, or replace it with a placeholder or screenshot.
-- **Sourcing:** remote asset URLs expire in ~7 days. For committed code, download the exact bytes or use the project's data source.
-- **Reuse a project icon component only if its glyph clearly matches**; otherwise use the exported asset.
-- **Preserve designed geometry:** You MUST preserve the outer asset box and inner leaf separately, including both dimensions, padding, and aspect ratio.
-- Relative fill sizing is allowed only if you verified the container constrains the leaf; otherwise set both leaf dimensions explicitly. You MUST NOT use `auto` for a fixed-size leaf.
-- You MUST NOT apply one global size to unlike assets or stretch assets through broad descendant rules.
-
-#### G5 - Asset Fidelity
-
-To pass G5:
-- You MUST use the correct source for every asset.
-- You MUST verify one representative of each shared sizing rule and every exception preserves intended outer and leaf dimensions.
-- You MUST NOT pass on source evidence alone when geometry is unverified.
-
-G5 PASS - `<sources; sizing rules and exceptions; rendered or explicit-dimension evidence>`
-
-Otherwise G5 is `FAIL`. You MUST fix it before finishing.
+- **Render every icon/image from its exported asset.** Never hand-write or inline `<svg>`/`<path>`, never author your own icon file, never drop an icon or leave a placeholder — you don't have the real vector data, so anything you draw is wrong.
+- **Sourcing:** the asset URL works directly as `src` for an immediate render, but it **expires in ~7 days** — so for code you'll commit, download-and-commit the exact asset bytes, or wire a dynamic content image to the project's data source (API, CDN, or props). Never a file whose contents you authored.
+- **Reuse a project icon component only if its glyph clearly matches** (a name match is not enough); otherwise use the exported asset.
+- **Size explicitly:** a fixed-size container (icons are usually square, e.g. `size-[24px]`, `overflow-clip`) with BOTH width and height set, and size the leaf `<img>` to fill it (`100%` or fixed px) — never `auto`, which blows the image up to its intrinsic size.
 
 ## Error Recovery
 

--- a/skills/figma-design-to-code/SKILL.md
+++ b/skills/figma-design-to-code/SKILL.md
@@ -19,10 +19,23 @@ This skill owns the **workflow** for design-to-code. Parameter mechanics (nodeId
 
 ## Workflow
 
+### Gate Protocol
+
+- Emit exactly three terse gate messages: G1 after design context returns; one combined G2-G4 check before editing; and G5 before finishing. Do not narrate gates between checkpoints.
+- A `PASS` MUST cite evidence produced by the required work. You MUST NOT make tool calls solely to emit a gate.
+- Gather sufficient evidence for the implementation, not exhaustive evidence. If a requirement is unmet, emit `FAIL`, fix it, then restate the gate.
+- You MUST NOT write code until G1 and G2-G4 pass. You MUST NOT finish until G5 passes.
+- Gates are self-checks. You MUST NOT change the implementation solely to produce gate evidence.
+
 ### 1. Call get_design_context first
 
 - You MUST call `get_design_context` on the target node before writing any code. It is your primary tool — a single call returns reference code, a screenshot, and contextual hints.
 - You MUST NOT reach for `get_metadata` or `get_screenshot` as a substitute. Use them only to orient (e.g. picking a node) or to validate, not in place of `get_design_context`.
+- If the response is sparse metadata, request only the visible child regions needed to implement the target, preferably in one parallel batch.
+
+#### G1 - Design Context
+
+G1 PASS - `<target node; one-line summary of retrieved HTML-format design regions>`
 
 ### 2. Treat the output as a reference, not final code
 
@@ -31,12 +44,12 @@ This skill owns the **workflow** for design-to-code. Parameter mechanics (nodeId
 
 ### 3. Reuse what the project already has
 
-- Before writing new code, You MUST check the target project for existing components, layout patterns, and design tokens that match the design intent.
+- Before writing new code, You MUST check likely project-owned paths for existing components, layout patterns, and design tokens that match the design intent.
 - You MUST reuse the project's existing components and tokens instead of generating new equivalents from scratch.
 
 ### 4. Honor the response hints by priority
 
-Apply the hints in this order — earlier sources override later ones:
+You MUST apply only hint sources that are present and relevant, in this order — earlier sources override later ones:
 
 1. **Code Connect snippets** → use the mapped codebase component directly.
 2. **Component documentation links** → follow them for usage and guidelines.
@@ -44,14 +57,35 @@ Apply the hints in this order — earlier sources override later ones:
 4. **Design tokens (CSS variables)** → map them to the project's token system.
 5. **Raw hex / absolute positioning** → loosely structured; lean on the screenshot for intent.
 
+#### G2-G4 - Pre-edit
+
+- **G2:** You MUST identify the target stack and adapt the reference to it.
+- **G3:** You MUST search likely project-owned paths and identify what will be reused.
+- **G4:** You MUST apply present, relevant hints by priority. You MUST NOT search merely to prove a hint is absent.
+
+G2-G4 PASS - `<stack/path; reuse search/result; present hints/application>`
+
 ### 5. Reproduce images and icons faithfully
 
-Images and icons come back as `<img>` elements whose `src` is a remote asset URL (`https://.../api/mcp/asset/...`). Apply these rules as you write the code:
+Images and icons come back as exported assets. Apply these rules as you write the code:
 
-- **Render every icon/image from its exported asset.** Never hand-write or inline `<svg>`/`<path>`, never author your own icon file, never drop an icon or leave a placeholder — you don't have the real vector data, so anything you draw is wrong.
-- **Sourcing:** the asset URL works directly as `src` for an immediate render, but it **expires in ~7 days** — so for code you'll commit, download-and-commit the exact asset bytes, or wire a dynamic content image to the project's data source (API, CDN, or props). Never a file whose contents you authored.
-- **Reuse a project icon component only if its glyph clearly matches** (a name match is not enough); otherwise use the exported asset.
-- **Size explicitly:** a fixed-size container (icons are usually square, e.g. `size-[24px]`, `overflow-clip`) with BOTH width and height set, and size the leaf `<img>` to fill it (`100%` or fixed px) — never `auto`, which blows the image up to its intrinsic size.
+- **Render every icon/image from its exported asset.** Never author, redraw, omit, or replace it with a placeholder or screenshot.
+- **Sourcing:** remote asset URLs expire in ~7 days. For committed code, download the exact bytes or use the project's data source.
+- **Reuse a project icon component only if its glyph clearly matches**; otherwise use the exported asset.
+- **Preserve designed geometry:** You MUST preserve the outer asset box and inner leaf separately, including both dimensions, padding, and aspect ratio.
+- Relative fill sizing is allowed only if you verified the container constrains the leaf; otherwise set both leaf dimensions explicitly. You MUST NOT use `auto` for a fixed-size leaf.
+- You MUST NOT apply one global size to unlike assets or stretch assets through broad descendant rules.
+
+#### G5 - Asset Fidelity
+
+To pass G5:
+- You MUST use the correct source for every asset.
+- You MUST verify one representative of each shared sizing rule and every exception preserves intended outer and leaf dimensions.
+- You MUST NOT pass on source evidence alone when geometry is unverified.
+
+G5 PASS - `<sources; sizing rules and exceptions; rendered or explicit-dimension evidence>`
+
+Otherwise G5 is `FAIL`. You MUST fix it before finishing.
 
 ## Error Recovery
 

--- a/skills/figma-generate-design/SKILL.md
+++ b/skills/figma-generate-design/SKILL.md
@@ -123,14 +123,14 @@ get_libraries({ fileKey })
 // }
 
 // Step 2: Search within a specific library using its libraryKey
-search_design_system({ query: "button", fileKey, includeLibraryKeys: ["lk-abc123..."] })
+search_design_system({ queries: [{ entity: "component", query: "button" }], fileKey, includeLibraryKeys: ["lk-abc123..."] })
 ```
 
 Org libraries in `libraries_available_to_add` are paginated (20 per page). When `libraries_available_to_add_next_offset` is non-null, more org libraries are available — call `get_libraries` again with `offset` set to that value to fetch the next page. Community UI kits only appear on the first page. If the user names a specific library you don't see in the current page, page further before giving up.
 
 This is especially useful when the file has many libraries and you want targeted results (e.g. searching only within "iOS 26" or "Material 3" instead of getting matches from every library).
 
-**Search broadly, but one intent per query** — `search_design_system` does NOT apply OR semantics, so never pack alternatives or synonyms into a single string ("Button IconButton icon" matches nothing useful). Issue a separate call per term and run them in parallel: "button", "input", "nav", "card", "accordion", "header", "footer", "tag", "avatar", "toggle", "icon", etc. Multi-word names and phrases are fine when they name one thing ("Material Design Icons"). Use `includeComponents: true` to focus on components.
+**Search broadly, but one intent per query** — `search_design_system` does NOT apply OR semantics, so never pack alternatives or synonyms into a single string ("Button IconButton icon" matches nothing useful). Pass each term as a component entry in one `queries` call: `{ entity: "component", query: "button" }`, `{ entity: "component", query: "input" }`, `{ entity: "component", query: "nav" }`, etc. Multi-word names and phrases are fine when they name one thing ("Material Design Icons").
 
 **Include component properties** in your map — you need to know which TEXT properties each component exposes for text overrides. Create a temporary instance, read its `componentProperties` (and those of nested instances), then remove the temp instance.
 
@@ -148,16 +148,16 @@ Component Map:
 
 #### 2b: Discover variables (colors, spacing, radii)
 
-**Inspect existing screens first** (same as components). Or use `search_design_system` with `includeVariables: true`.
+**Inspect existing screens first** (same as components). Or use `search_design_system` with `queries` entries whose `entity` is `"variable"`.
 
 > **WARNING: Two different variable discovery methods — do not confuse them.**
 >
 > - `use_figma` with `figma.variables.getLocalVariableCollectionsAsync()` — returns **only local variables defined in the current file**. If this returns empty, it does **not** mean no variables exist. Remote/published library variables are invisible to this API.
-> - `search_design_system` with `includeVariables: true` — searches across **all linked libraries**, including remote and published ones. This is the correct tool for discovering design system variables.
+> - `search_design_system` with `entity: "variable"` query entries — searches across **all linked libraries**, including remote and published ones. This is the correct tool for discovering design system variables.
 >
-> **Never conclude "no variables exist" based solely on `getLocalVariableCollectionsAsync()` returning empty.** Always also run `search_design_system` with `includeVariables: true` to check for library variables before deciding to create your own.
+> **Never conclude "no variables exist" based solely on `getLocalVariableCollectionsAsync()` returning empty.** Always also run `search_design_system` with variable query entries to check for library variables before deciding to create your own.
 
-**Query strategy:** `search_design_system` matches against **variable names** (e.g., "Gray/gray-9", "core/gray/100", "space/400"), not categories. Run multiple short, simple queries in parallel rather than one compound query:
+**Query strategy:** `search_design_system` matches against **variable names** (e.g., "Gray/gray-9", "core/gray/100", "space/400"), not categories. Put multiple short, simple queries in one `queries` call rather than one compound query:
 
 - **Primitive colors:** "gray", "red", "blue", "green", "white", "brand"
 - **Semantic colors:** "background", "foreground", "border", "surface", "text"
@@ -195,7 +195,7 @@ See [variable-patterns.md](../figma-use/references/variable-patterns.md) for bin
 
 #### 2c: Discover styles (text styles, effect styles)
 
-Search for styles using `search_design_system` with `includeStyles: true` and terms like "heading", "body", "shadow", "elevation". Or inspect what an existing screen uses:
+Search for styles using `search_design_system` with `entity: "style"` query entries and terms like "heading", "body", "shadow", "elevation". Or inspect what an existing screen uses:
 
 ```js
 const frame = figma.currentPage.findOne(n => n.name === "Existing Screen");
@@ -464,7 +464,7 @@ Because this skill works incrementally (one section per call), errors are natura
 ## Best Practices
 
 - **Always search before building.** The design system likely has the component, variable, or style you need. Manual construction and hardcoded values should be the exception, not the rule.
-- **Search broadly, one intent per query.** Try synonyms and partial terms as *separate* parallel searches, never combined into one string — a "NavigationPill" might be found under "pill", "nav", "tab", or "chip", so run those as four queries. For variables, search "color", "spacing", "radius", etc.
+- **Search broadly, one intent per query.** Try synonyms and partial terms as separate `{ entity, query }` entries in one `queries` call, never combined into one string — a "NavigationPill" might be found under "pill", "nav", "tab", or "chip", so pass those as four component entries. For variables, use `entity: "variable"` with queries like "color", "spacing", "radius", etc.
 - **Prefer design system tokens over hardcoded values.** Use variable bindings for colors, spacing, and radii. Use text styles for typography. Use effect styles for shadows. This keeps the screen linked to the design system.
 - **Prefer component instances over manual builds.** Instances stay linked to the source component and update automatically when the design system evolves.
 - **Componentize by default.** Build repeated or reusable elements as a component once, then place instances. Do not ship a flat tree of one-off frames that needs a second "make it componentized" pass.

--- a/skills/figma-generate-library/SKILL.md
+++ b/skills/figma-generate-library/SKILL.md
@@ -212,10 +212,17 @@ If `libraries_available_to_add_next_offset` is non-null, more org libraries are 
 
 ```
 // Search across all libraries (default)
-search_design_system({ query, fileKey, includeComponents: true, includeVariables: true, includeStyles: true })
+search_design_system({
+  queries: [
+    { entity: "component", query },
+    { entity: "variable", query },
+    { entity: "style", query }
+  ],
+  fileKey
+})
 
 // Search within a specific library only
-search_design_system({ query, fileKey, includeLibraryKeys: ["lk-abc123..."], includeComponents: true })
+search_design_system({ queries: [{ entity: "component", query }], fileKey, includeLibraryKeys: ["lk-abc123..."] })
 ```
 
 **Reuse if** all of these are true:

--- a/skills/figma-generate-library/references/discovery-phase.md
+++ b/skills/figma-generate-library/references/discovery-phase.md
@@ -336,7 +336,7 @@ get_libraries({ fileKey: "abc123", offset: 20 })
 
 ### Step 2: Search with `search_design_system`
 
-`search_design_system` runs three parallel searches against design libraries for the given file:
+`search_design_system` searches design libraries for the given file. Each `queries` entry names one entity type:
 
 1. **Components** — published library components, searched by name/description via a recommendation engine (relevance-ranked, not exact match)
 2. **Variables** — design tokens (colors, spacing, etc.) across subscribed libraries
@@ -349,19 +349,19 @@ By default it searches all accessible libraries. Pass `includeLibraryKeys` to se
 ```
 // Search all libraries
 search_design_system({
-  query: "button",              // required — text query
-  fileKey: "abc123",            // required — your file key
-  includeComponents: true,      // default true
-  includeVariables: true,       // default true
-  includeStyles: true           // default true
+  queries: [
+    { entity: "component", query: "button" },
+    { entity: "variable", query: "color" },
+    { entity: "style", query: "heading" }
+  ],
+  fileKey: "abc123"            // required — your file key
 })
 
 // Search a specific library only (use libraryKey from get_libraries)
 search_design_system({
-  query: "button",
+  queries: [{ entity: "component", query: "button" }],
   fileKey: "abc123",
-  includeLibraryKeys: ["lk-abc123..."],
-  includeComponents: true
+  includeLibraryKeys: ["lk-abc123..."]
 })
 ```
 
@@ -369,30 +369,44 @@ search_design_system({
 
 ```json
 {
-  "components": [
+  "results": [
     {
-      "name": "Button",
-      "libraryName": "Design System",
-      "assetType": "component_set",
-      "componentKey": "abc123def",
-      "description": "Primary action button"
-    }
-  ],
-  "variables": [
+      "entity": "component",
+      "query": "button",
+      "components": [
+        {
+          "name": "Button",
+          "libraryName": "Design System",
+          "assetType": "component_set",
+          "componentKey": "abc123def",
+          "description": "Primary action button"
+        }
+      ]
+    },
     {
-      "name": "colors/primary/500",
-      "variableType": "COLOR",
-      "variableSetKey": "set1key",
-      "key": "var1key",
-      "scopes": ["FRAME_FILL", "SHAPE_FILL"],
-      "variableCollectionName": "Colors"
-    }
-  ],
-  "styles": [
+      "entity": "variable",
+      "query": "color",
+      "variables": [
+        {
+          "name": "colors/primary/500",
+          "variableType": "COLOR",
+          "variableSetKey": "set1key",
+          "key": "var1key",
+          "scopes": ["FRAME_FILL", "SHAPE_FILL"],
+          "variableCollectionName": "Colors"
+        }
+      ]
+    },
     {
-      "name": "Heading/H1",
-      "styleType": "TEXT",
-      "key": "style1key"
+      "entity": "style",
+      "query": "heading",
+      "styles": [
+        {
+          "name": "Heading/H1",
+          "styleType": "TEXT",
+          "key": "style1key"
+        }
+      ]
     }
   ]
 }
@@ -413,7 +427,7 @@ const componentSet = await figma.importComponentSetByKeyAsync("abc123def");
 
 ### When to Search
 
-- **Phase 0, step 0c**: Search broadly (`query: "button"`, `query: "color"`, `query: "spacing"`) before planning anything. This establishes the reuse baseline.
+- **Phase 0, step 0c**: Search broadly (`queries: [{ entity: "component", query: "button" }, { entity: "variable", query: "color" }, { entity: "variable", query: "spacing" }]`) before planning anything. This establishes the reuse baseline.
 - **Immediately before each component creation**: Search for the specific component name before writing any `use_figma` creation code.
 
 **Reuse decision:**

--- a/skills/figma-use/references/effect-style-patterns.md
+++ b/skills/figma-use/references/effect-style-patterns.md
@@ -92,7 +92,7 @@ const shadowStyle = await figma.importStyleByKeyAsync("EFFECT_STYLE_KEY");
 node.effectStyleId = shadowStyle.id;
 ```
 
-`search_design_system` with `includeStyles: true` returns style keys you can import this way. Prefer importing library styles over creating new ones.
+A style found via a `search_design_system` `queries` entry with `entity: "style"` returns a style key you can import this way. Prefer importing library styles over creating new ones.
 
 ## Applying Effect Styles to Nodes
 

--- a/skills/figma-use/references/text-style-patterns.md
+++ b/skills/figma-use/references/text-style-patterns.md
@@ -166,7 +166,7 @@ const headingStyle = await figma.importStyleByKeyAsync("TEXT_STYLE_KEY");
 await textNode.setTextStyleIdAsync(headingStyle.id);
 ```
 
-`search_design_system` with `includeStyles: true` returns style keys you can import this way. Prefer importing library styles over creating new ones.
+A style found via a `search_design_system` `queries` entry with `entity: "style"` returns a style key you can import this way. Prefer importing library styles over creating new ones.
 
 ## Applying Text Styles to Nodes
 


### PR DESCRIPTION
## Summary

Updates five Figma MCP plugin skill files and bumps the release version to **2.2.108** so clients can pick up the changes. Updates the bundle header version to match the release.

## Validation

- Validated all five release manifests with `jq` and confirmed version `2.2.108`.
- Verified the bundle header version in `.mcp.json`.
